### PR TITLE
fix dark mode entry footer text

### DIFF
--- a/frontend/src/components/plurals/entry/entry.tsx
+++ b/frontend/src/components/plurals/entry/entry.tsx
@@ -7,7 +7,7 @@ import Text from '../../pieces/text/text'
 const styles = {
   titleLink: ['hover:underline'].join(' '),
   footer: [
-    'flex flex-col lg:flex-row justify-between mt-0.5 text-light-on-surface-medium',
+    'flex flex-col lg:flex-row justify-between mt-0.5 text-light-on-surface-medium dark:text-dark-on-surface-medium',
   ].join(' '),
   link: [
     'underline decoration-light-on-surface-medium dark:decoration-dark-on-surface-medium',


### PR DESCRIPTION
- **chore: update .gitignore to include backup files and node_modules**
- **重複したユーザー名を許可しない**
- **記事下部のテキストがダークモードでは白く表示されるよう修正**
