### PR TITLE
[Lambda Migration] Phase 4: コンテナイメージの縮小とarm64対応

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -63,11 +63,22 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      # arm64 (Lambda/Graviton向け) をamd64ランナー上でクロスビルドするためQEMUが必要。
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      # amd64は本番EC2 (t2.nano)、arm64はLambda (Graviton) 向け。
+      # 両方をpushしておくことで、EC2は現行通りamd64をpullし続けつつ、
+      # Lambda移行時にarm64をpullできる。
       - name: Build and push Docker image
         uses: docker/build-push-action@v7.3.0
         with:
           context: ./backend
           push: true
+          platforms: linux/amd64,linux/arm64
           build-args: |
             JAVA_DOCKER_TAG=${{ steps.java-tag.outputs.java_docker_tag }}
           tags: miyado/kottage:latest, miyado/kottage:${{ env.new_version }}

--- a/backend/.editorconfig
+++ b/backend/.editorconfig
@@ -4,3 +4,15 @@ ktlint_standard = disabled
 [*.{kt,kts}]
 ij_kotlin_allow_trailing_comma = true
 ij_kotlin_allow_trailing_comma_on_call_site = true
+
+# シェルスクリプトの整形規約。
+# super-linter の SHELL_SHFMT (shfmt) はフォーマット系フラグが渡されない場合
+# .editorconfig を参照するため、既存のスタイルをここで宣言して一貫させる。
+#   indent_style/indent_size = space 2   -> shfmt -i 2
+#   switch_case_indent       = true      -> shfmt -ci  (case ラベルをインデント)
+#   binary_next_line         = true      -> shfmt -bn  (パイプ等を次行の先頭に置く)
+[*.sh]
+indent_style = space
+indent_size = 2
+switch_case_indent = true
+binary_next_line = true

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,10 +1,19 @@
 # JAVA_DOCKER_TAG はリポジトリルートの mise.toml から
 # scripts/mise-java-docker-tag.sh で組み立てた値 (バージョン + ベースOS) を
 # 渡すこと (docker build --build-arg)。
-ARG JAVA_DOCKER_TAG=21.0.11_10-jdk-ubi9-minimal
+#
+# installDist の出力 (起動スクリプト + jar) を実行するだけなのでコンパイラ等を含む
+# JDK は不要。JRE タグを使いイメージサイズを削減する。
+#
+# eclipse-temurin の各タグは linux/amd64 と linux/arm64 の両方を含むマルチアーキ
+# イメージなので、`docker buildx build --platform linux/amd64,linux/arm64` で
+# そのままマルチアーキビルドできる。
+ARG JAVA_DOCKER_TAG=21.0.11_10-jre-ubi9-minimal
 FROM eclipse-temurin:${JAVA_DOCKER_TAG}
-EXPOSE 8080:8080
-RUN microdnf install -y findutils
+EXPOSE 8080
+# findutils (find/xargs) はベースイメージに標準で含まれているため追加インストール不要。
+# installDist が生成する起動スクリプト (build/install/kottage/bin/kottage) は
+# xargs を使用するが、findutils を明示インストールしなくても既に利用可能。
 RUN mkdir /app
 COPY ./build/install/kottage/ /app/
 WORKDIR /app/bin

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     build:
       context: .
       args:
-        JAVA_DOCKER_TAG: ${JAVA_DOCKER_TAG:-21.0.11_10-jdk-ubi9-minimal}
+        JAVA_DOCKER_TAG: ${JAVA_DOCKER_TAG:-21.0.11_10-jre-ubi9-minimal}
     container_name: kottage
     ports:
       - "8080:8080"

--- a/backend/scripts/mise-java-docker-tag.sh
+++ b/backend/scripts/mise-java-docker-tag.sh
@@ -36,4 +36,4 @@ case "$MAJOR_VERSION" in
     ;;
 esac
 
-echo "${VERSION_TAG}-jdk-${UBI_VARIANT}"
+echo "${VERSION_TAG}-jre-${UBI_VARIANT}"


### PR DESCRIPTION
## 概要

Lambda移行プロジェクト フェーズ4: コンテナイメージを縮小し、arm64（Graviton）対応を追加する。

計画書: `docs/projects/lambda/migration-plan.md`（フェーズ0のPRで追加）

## 変更内容

- **JDK → JRE 化**: `installDist` の出力（起動スクリプト + jar）を実行するだけならコンパイラは不要
  - `backend/scripts/mise-java-docker-tag.sh` の出力を `-jdk-` → `-jre-` に変更。`mise.toml` をSSOTとする既存の仕組みとUBIバリアント判定ロジックは無変更
  - `backend/Dockerfile` と `backend/docker-compose.yml` のデフォルトタグを同期
- **`microdnf install -y findutils` を削除**（下記の検証を経て不要と判明）
- **`EXPOSE 8080:8080` → `EXPOSE 8080`**: `EXPOSE` はポート番号のみを取り、ホスト側マッピングは指定できないため記法として誤りだった
- **マルチアーキテクチャ対応**: `.github/workflows/delivery.yml` に `docker/setup-qemu-action@v4` と `docker/setup-buildx-action@v4` を追加し、`build-push-action` に `platforms: linux/amd64,linux/arm64` を指定

## イメージサイズ（実測）

| | サイズ |
|---|---|
| 変更前（JDK + findutils） | 559MB |
| **変更後（JRE、findutils削除）** | **404MB** |
| 変更後 arm64 | 419MB |

**約28%削減。ただし計画の目標だった300MB以下には届いていない。**

原因: `eclipse-temurin:*-jre-ubi9-minimal` ベースイメージ自体が単体で364MBある。temurinの公式Dockerfileがマルチステージビルドになっておらず、JREバイナリを取得・検証するための `wget`/`gpg`/`tar` 等がランタイムイメージに焼き込まれているため。

参考値: `eclipse-temurin:21.0.11_10-jre-alpine` は単体207MB。

## なぜマルチアーキにするのか

Lambdaをarm64で動かすと料金が2割安い。しかし現行の本番EC2は `t2.nano`（x86_64）であり、arm64単独イメージにすると**EC2での事前検証ができなくなる**。移行計画は「アプリ変更を現行EC2で本番検証してからLambdaへ移行する」ことをリスク低減の柱にしているため、両アーキテクチャをサポートしてEC2はamd64、Lambdaはarm64をpullする形にした。

フェーズ9でEC2を撤去した後、amd64ビルドを落とせる。

## findutils削除の根拠（実機確認済み）

1. `backend/build/install/kottage/bin/kottage`（gradle installDistが生成する起動スクリプト）を読み、`find` は未使用、`xargs` はJVMオプション解析で必須（`command -v xargs` がなければ `die` する）と判別
2. 実際にコンテナ内で `rpm -q findutils` を実行し、`findutils-4.8.0-7.el9` がベースイメージに**標準で含まれている**ことを確認（JDK版・JRE版とも）

つまりこの行は最初から不要だった。推測ではなく実機で確認している。

なお、これは現在のベースイメージタグでの事実であり、将来temurinが `ubi9-minimal` からfindutilsを外すと起動スクリプトが壊れる。Dockerfileにコメントとして根拠を残してある。

## テスト

- [x] `./gradlew clean installDist` 成功
- [x] amd64イメージ（QEMU経由、`uname -m` で `x86_64` 確認）: コンテナ起動、`/api/v1/health` が HTTP 200 で `{"description":"OK",...,"databaseType":"mysql"}`
- [x] arm64イメージ（Apple Siliconでネイティブ実行、`uname -m` で `aarch64` 確認）: 同様に HTTP 200
- [x] 両アーキテクチャで `find`/`xargs` がコンテナ内で利用可能なことを確認

## 未解決 / 判断が必要な点

**Alpine化またはjlinkによるさらなる縮小は、フェーズ7の計測後に判断することを提案する。**

- イメージが小さいほどLambdaのコールドスタートが速くなるため、フェーズ7の判断ゲートに直結する
- しかしAlpineはmusl libcになり、Nettyのネイティブトランスポート等でリスクがある（NIOフォールバックで動く見込みだが未検証）
- `mise-java-docker-tag.sh` のUBI前提のSSOT設計から外れる
- **200MBの差がコールドスタートに実際どれだけ効くか、まだ測定していない**

フェーズ7で実測すれば根拠を持って判断できる。推測で最適化する前に測る方針。

## 既知の競合

`.github/workflows/delivery.yml` はフェーズ5（ECR + OIDC）のPRとも競合する。両方必要な変更が隣接行にあるだけなので、先にマージされた側に合わせてもう一方をrebaseして解消する。

## レビュー観点

- `mise-java-docker-tag.sh` の変更が既存のSSOT方針を壊していないか
- findutils削除の根拠が妥当か
- マルチアーキ採用の判断（arm64単独にしない理由）
- 300MB目標未達を許容するか、Alpine化を今やるか

## チェックリスト

- [x] イメージがビルドできる（両アーキテクチャ）
- [x] コンテナが起動しヘルスチェックが通る
- [x] `mise.toml` をSSOTとする既存方針を維持している
- [ ] レビュー完了

Related: Lambda Migration Phase 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)
