### PR TITLE
[Lambda Migration] Phase 5: ECRリポジトリとGitHub Actions OIDC連携

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -31,6 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: check_changes
     if: github.event_name == 'workflow_dispatch' || needs.check_changes.outputs.backend == 'true'
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Check out the repo
         uses: actions/checkout@v7
@@ -63,6 +66,18 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      # 長期AWSクレデンシャルを持たずOIDCでロールを引き受ける。
+      # ロールARNはリポジトリVariable (機密ではないためSecretにしていない)。
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_GITHUB_ACTIONS_ROLE_ARN }}
+          aws-region: us-east-2
+
+      - name: Log in to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+        id: ecr-login
+
       # arm64 (Lambda/Graviton向け) をamd64ランナー上でクロスビルドするためQEMUが必要。
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -73,6 +88,7 @@ jobs:
       # amd64は本番EC2 (t2.nano)、arm64はLambda (Graviton) 向け。
       # 両方をpushしておくことで、EC2は現行通りamd64をpullし続けつつ、
       # Lambda移行時にarm64をpullできる。
+      # Docker HubとECRの両方にpushする (移行期間中はEC2がDocker Hubから取得するため)。
       - name: Build and push Docker image
         uses: docker/build-push-action@v7.3.0
         with:
@@ -81,4 +97,4 @@ jobs:
           platforms: linux/amd64,linux/arm64
           build-args: |
             JAVA_DOCKER_TAG=${{ steps.java-tag.outputs.java_docker_tag }}
-          tags: miyado/kottage:latest, miyado/kottage:${{ env.new_version }}
+          tags: miyado/kottage:latest, miyado/kottage:${{ env.new_version }}, ${{ steps.ecr-login.outputs.registry }}/kottage:latest, ${{ steps.ecr-login.outputs.registry }}/kottage:${{ env.new_version }}

--- a/backend/infra/ecr.tf
+++ b/backend/infra/ecr.tf
@@ -1,0 +1,34 @@
+resource "aws_ecr_repository" "kottage" {
+  name = "kottage"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = {
+    Name    = "kottage"
+    Service = "kottage"
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "kottage" {
+  repository = aws_ecr_repository.kottage.name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Keep only the last 10 tagged images"
+        selection = {
+          tagStatus      = "tagged"
+          tagPatternList = ["*"]
+          countType      = "imageCountMoreThan"
+          countNumber    = 10
+        }
+        action = {
+          type = "expire"
+        }
+      }
+    ]
+  })
+}

--- a/backend/infra/github_oidc.tf
+++ b/backend/infra/github_oidc.tf
@@ -1,0 +1,94 @@
+# GitHub Actions OIDC federation so CI can push images to ECR without
+# long-lived AWS credentials.
+#
+# NOTE: an AWS account can only have one OIDC provider per issuer URL.
+# Before running `terraform apply`, check whether
+# token.actions.githubusercontent.com is already registered, e.g.:
+#   aws iam list-open-id-connect-providers
+# or, if a local state file exists:
+#   jq '.resources[] | select(.type=="aws_iam_openid_connect_provider")' terraform.tfstate
+# If it already exists, set create_github_oidc_provider = false in
+# sensitive.tfvars (or via -var) and either import the existing resource
+# or leave it managed outside this module.
+locals {
+  github_oidc_provider_arn = (
+    var.create_github_oidc_provider
+    ? aws_iam_openid_connect_provider.github_actions[0].arn
+    : "arn:aws:iam::${var.aws_account_id}:oidc-provider/token.actions.githubusercontent.com"
+  )
+}
+
+resource "aws_iam_openid_connect_provider" "github_actions" {
+  count = var.create_github_oidc_provider ? 1 : 0
+
+  url            = "https://token.actions.githubusercontent.com"
+  client_id_list = ["sts.amazonaws.com"]
+
+  # GitHub's OIDC thumbprint (DigiCert Global Root CA). AWS no longer relies
+  # on this value for validation (it verifies against its own trusted CA
+  # store since 2023), but the argument is still required by the resource.
+  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+
+  tags = {
+    Name    = "github-actions-oidc"
+    Service = "kottage"
+  }
+}
+
+resource "aws_iam_role" "github_actions_ecr_push" {
+  name = "kottage_github_actions_ecr_push"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = {
+          Federated = local.github_oidc_provider_arn
+        },
+        Action = "sts:AssumeRoleWithWebIdentity",
+        Condition = {
+          StringEquals = {
+            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          },
+          StringLike = {
+            "token.actions.githubusercontent.com:sub" = "repo:hmiyado/kottage:*"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = {
+    Name    = "kottage_github_actions_ecr_push"
+    Service = "kottage"
+  }
+}
+
+resource "aws_iam_role_policy" "github_actions_ecr_push" {
+  name = "ecr_push"
+  role = aws_iam_role.github_actions_ecr_push.id
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = [
+          "ecr:GetAuthorizationToken"
+        ],
+        Resource = "*"
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:InitiateLayerUpload",
+          "ecr:UploadLayerPart",
+          "ecr:CompleteLayerUpload",
+          "ecr:PutImage",
+          "ecr:BatchGetImage"
+        ],
+        Resource = aws_ecr_repository.kottage.arn
+      }
+    ]
+  })
+}

--- a/backend/infra/variables.tf
+++ b/backend/infra/variables.tf
@@ -21,3 +21,9 @@ variable "main_availability_zones" {
 variable "kottage_port" {
   type = string
 }
+
+variable "create_github_oidc_provider" {
+  type        = bool
+  default     = true
+  description = "Whether to create the token.actions.githubusercontent.com OIDC provider. Set to false if it already exists in this AWS account (an account can only have one provider per issuer URL)."
+}


### PR DESCRIPTION
## 概要

Lambda移行プロジェクト フェーズ5: LambdaがコンテナイメージをpullできるようECRリポジトリを用意し、GitHub ActionsからOIDCでpushできるようにする。

**追加のみの変更で、既存のDocker Hub経路は維持している。** 移行期間中は現行EC2がDocker Hubから取得し続けるため。

計画書: `docs/projects/lambda/migration-plan.md`（フェーズ0のPRで追加）

## 変更内容

### `backend/infra/ecr.tf`（新規）

- `aws_ecr_repository.kottage` — push時の脆弱性スキャンを有効化（無料）
- `aws_ecr_lifecycle_policy.kottage` — 直近10世代のタグ付きイメージのみ保持

ライフサイクルポリシーを入れる理由: `delivery.yml` は毎回 `:latest` と `:${version}` の2タグをpushするため、放置するとバージョンタグが積み上がる。ベースイメージのレイヤーは共有されるので増分は数十MBだが、恒久的に $0.05/月以下に収めるために設定する。

### `backend/infra/github_oidc.tf`（新規）

- `aws_iam_openid_connect_provider.github_actions` — `token.actions.githubusercontent.com` を登録
- `aws_iam_role.github_actions_ecr_push` — 信頼ポリシーを `repo:hmiyado/kottage:*` に限定。`aud`（StringEquals）と `sub`（StringLike）の両方の条件を設定
- `aws_iam_role_policy.github_actions_ecr_push` — 最小権限。`ecr:GetAuthorizationToken` のみ Resource `*`（AWSの仕様上アカウントレベルのアクションのため）、残りはリポジトリARN限定。ワイルドカードアクションは使っていない

これにより GitHub Actions から**長期AWSクレデンシャルなしで**ECRにpushできる。

### `backend/infra/variables.tf`

- `create_github_oidc_provider`（bool、デフォルト `true`）を追加。AWSアカウントには同一issuerのOIDCプロバイダを1つしか登録できないため、既存がある場合に作成をスキップできるようにした

**確認済み**: 実 `terraform.tfstate` を確認したところ既存のOIDCプロバイダは**存在しない**（既存IAMロールは `http_proxy` のみ）。したがってデフォルトの `true` のままapplyできる。

### `.github/workflows/delivery.yml`

- `deploy_backend` ジョブに `permissions: { id-token: write, contents: read }` を追加
- `aws-actions/configure-aws-credentials@v4`（OIDCでロール引き受け）と `aws-actions/amazon-ecr-login@v2` を追加
- `build-push-action` の `tags` にECRのタグを**追加**（Docker Hubの2タグはそのまま維持）

## マージ前に人間が設定する必要があるもの

1. **リポジトリ Variable `AWS_GITHUB_ACTIONS_ROLE_ARN`** — `terraform apply` 後に `aws_iam_role.github_actions_ecr_push` のARNを設定する。ロールARNは機密ではないためSecretではなくVariableを使っている（Secretにしたい場合はワークフローの `vars.` を `secrets.` に変更）
2. **`terraform apply`** — `cd backend/infra && terraform plan -var-file="sensitive.tfvars"` で差分が追加のみであることを確認した後、`make apply`
3. 既存の `DOCKER_USERNAME` / `DOCKER_PASSWORD` は引き続き必要（Docker Hub経路を維持しているため）

## テスト

- [x] `terraform fmt -check` — 新規・変更ファイルはすべて通る
- [x] `terraform init -backend=false` と `terraform validate` — "Success! The configuration is valid."
- [x] `.github/workflows/delivery.yml` のYAMLパース確認
- [x] `terraform plan` / `apply` は**実行していない**（AWS認証が必要なため、レビュー後に人間が実施）

## 補足

- `terraform fmt` をディレクトリ全体にかけると既存の5ファイル（`api_gateway.tf`, `ec2.tf`, `iam.tf`, `lambda.tf`, `security_group.tf`）も整形される。これは本変更以前から存在する状態なので、差分ノイズを避けるため元に戻してある
- OIDCのthumbprintは既知のDigiCert Global Root CAの値をハードコードしている（`hashicorp/tls` プロバイダを追加するのを避けるため）。AWSは2023年以降この値ではなく自身の信頼CAストアで検証しているが、リソースの必須引数のため設定が必要

## レビュー観点

- **信頼ポリシーの `sub` が `repo:hmiyado/kottage:*` になっている**。これだと同リポジトリの任意のブランチからECR pushロールを引ける。より厳格にするなら `repo:hmiyado/kottage:ref:refs/heads/main` に絞れるが、`workflow_dispatch` をmain以外のブランチから実行できなくなるトレードオフがある。**どちらを採るか判断してほしい**
- ECR権限の粒度が適切か
- ライフサイクルポリシーの世代数（10）が妥当か
- Variable と Secret のどちらでロールARNを渡すか

## 既知の競合

`.github/workflows/delivery.yml` はフェーズ4（イメージ最適化）のPRとも競合する。両方必要な変更が隣接行にあるだけなので、先にマージされた側に合わせてもう一方をrebaseして解消する。

## チェックリスト

- [x] `terraform validate` が通る
- [x] `terraform fmt -check` が通る
- [x] 追加のみの変更であり既存のDocker Hub経路を壊していない
- [x] IAM権限が最小限である
- [ ] レビュー完了

Related: Lambda Migration Phase 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
