### PR TITLE
fix(ci): Delivery の発火条件を修正 (ワークフロー変更を対象に含める / マージ時のみデプロイ)

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -24,6 +24,11 @@ jobs:
           filters: |
             backend:
               - 'backend/**'
+              # ワークフロー定義自体の変更もデプロイ対象にする。
+              # これがないと、デプロイ手順 (action のバージョン、認証、push先など) を
+              # 変更しても Deploy Backend が skip され、変更が検証されないまま残る。
+              # ci.yml のフィルタと揃えてある。
+              - '.github/workflows/**'
               - 'mise.toml'
 
   deploy_backend:

--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -35,7 +35,13 @@ jobs:
     name: Deploy Backend
     runs-on: ubuntu-latest
     needs: check_changes
-    if: github.event_name == 'workflow_dispatch' || needs.check_changes.outputs.backend == 'true'
+    # pull_request の closed はマージせずに閉じた場合も発火するため、
+    # merged を明示的に確認する。これがないとPRを閉じただけでデプロイが走る。
+    # workflow_dispatch は手動実行なので merged の判定対象外。
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true &&
+      needs.check_changes.outputs.backend == 'true')
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
## 概要

`delivery.yml` のデプロイ発火条件に関する2つの問題を修正する。

## 問題1: ワークフロー定義の変更でデプロイが走らない

paths-filter が `backend/**` と `mise.toml` しか対象にしておらず、**ワークフロー定義自体を変更しても `Deploy Backend` が skip される**。`if` 条件で除外されるだけなので**ワークフロー全体は「成功」と表示され、見落としやすい**。

実際に #528（`aws-actions/configure-aws-credentials` を v4 → v6 に更新）で起きた:

```
Check file changes: success
Deploy Backend: skipped     ← OIDC の経路が一度も実行されていない
```

ECR のイメージも #527 マージ時のものから変わっておらず、**v6 への更新は検証されないまま main に入った**状態だった。もし v6 に破壊的変更があれば、後日まったく無関係な backend の変更をデプロイしたときに初めて壊れる。原因の切り分けが難しい形の失敗になる。

### 修正

`.github/workflows/**` をフィルタに追加。「デプロイ手順の変更は、その手順自身によるデプロイで検証される」状態にする。

`ci.yml` は元々このフィルタを持っていて、`delivery.yml` だけが例外だった。両者を揃えた。

```yaml
backend:
  - 'backend/**'
  - '.github/workflows/**'   # 追加
  - 'mise.toml'
```

## 問題2: マージしなくてもデプロイが走る

`pull_request: types: [closed]` は**マージせずに閉じた場合も発火する**が、条件が `merged` を見ていなかった。つまり **PR を閉じただけで main のイメージが publish される**。

さらに問題1の修正でフィルタを広げると、この穴の影響範囲がわずかに広がる（ワークフローのみ変更した PR を閉じた場合にもデプロイが走るようになる）ため、同時に修正する。

### 修正

```yaml
if: >-
  github.event_name == 'workflow_dispatch' ||
  (github.event.pull_request.merged == true &&
  needs.check_changes.outputs.backend == 'true')
```

`workflow_dispatch` は手動実行で pull request コンテキストを持たないため対象外にしている。

## この PR 自身が検証になる

マージすると `.github/workflows/**` に該当するため `Deploy Backend` が実行される。つまり**この PR のマージが、修正が効いていることと #528 の v6 が実際に動くことの両方の検証になる**。

マージ後に確認すべき点:
- `Deploy Backend` が skip されず実行されること
- v6 の `configure-aws-credentials` で OIDC のロール引き受けが成功すること
- ECR に新しいマルチアーキイメージが push されること

逆に、もしこの PR を**マージせずに閉じた**場合はデプロイが走らないのが正しい挙動になる（問題2の修正）。

## 検証

- [x] Ruby の YAML パーサで構文を検証
- [x] paths-filter が `ci.yml` の `backend` フィルタと一致することを確認
- [x] `if` 条件が意図した式に展開されることを確認（`>-` の折り返しが正しく1行になる）

## 既知の競合

フェーズ3（DBマイグレーション分離）が `delivery.yml` にステップを追加する予定。触る箇所が異なる（本PRはフィルタと job 条件、フェーズ3はステップ）ため自動マージできる見込みだが、競合したら後発側で解消する。

## チェックリスト

- [x] YAML の構文が妥当
- [x] `ci.yml` のフィルタと一致
- [x] `workflow_dispatch` の手動実行が引き続き機能する条件になっている
- [ ] レビュー完了

🤖 Generated with [Claude Code](https://claude.com/claude-code)
