### PR TITLE
[Lambda Migration] Phase 6: Lambda Web Adapter の組み込み

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -16,5 +16,23 @@ EXPOSE 8080
 # xargs を使用するが、findutils を明示インストールしなくても既に利用可能。
 RUN mkdir /app
 COPY ./build/install/kottage/ /app/
+
+# Lambda Web Adapter: /opt/extensions/ 配下のLambda拡張はLambdaランタイム以外の
+# 環境 (EC2/docker-compose) では起動されないため、このCOPYを追加しても既存の
+# EC2上での動作には影響しない。同じイメージがEC2でもLambdaでも動く。
+# public.ecr.aws/awsguru/aws-lambda-adapter はマルチアーキ (amd64/arm64) 対応の
+# イメージであり、`docker buildx build --platform` のターゲットプラットフォームに
+# 応じて COPY --from が自動的に対応アーキテクチャのバイナリを解決する。
+# バージョンは https://github.com/awslabs/aws-lambda-web-adapter/releases の
+# 最新安定版 v1.0.1 (2026-05-28リリース) に固定。
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
+# ktor.deployment.port (application.conf) に合わせるポート。
+ENV AWS_LWA_PORT=8080
+# 既存のdocker-compose healthcheckと同じヘルスチェックパスを流用する。
+ENV AWS_LWA_READINESS_CHECK_PATH=/api/v1/health
+# JVMの初期化がLambdaのINITフェーズ (10秒制限) を超えても、最初のinvokeに
+# 処理を持ち越せるようにする。
+ENV AWS_LWA_ASYNC_INIT=true
+
 WORKDIR /app/bin
 CMD ["./kottage"]


### PR DESCRIPTION
## 概要

Lambda移行プロジェクト フェーズ6: Lambda Web Adapter をバックエンドのコンテナイメージに組み込む。

計画書: `docs/projects/lambda/migration-plan.md` のフェーズ6

## Lambda Web Adapter とは

awslabs製の小さなバイナリで、Lambda実行環境の中でアプリと並走し、Lambdaイベントを `127.0.0.1:8080` への通常のHTTPリクエストに変換する。**アプリ側は「ただのHTTPサーバー」のままでよく、Lambdaハンドラを書く必要がない。**

## この変更の最重要な性質: EC2 での動作を壊さない

アダプタは `/opt/extensions/` に置かれる **Lambda拡張**であり、**Lambdaランタイム以外の環境では起動されない**。したがって同じイメージが EC2 でも Lambda でも動く。

これは移行計画のリスク低減の柱（アプリ変更を現行EC2で本番検証してから移行する）を支える性質なので、検証で最重点に置いた。

## 変更内容

`backend/Dockerfile` のみ（18行追加）。

```dockerfile
COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
ENV AWS_LWA_PORT=8080
ENV AWS_LWA_READINESS_CHECK_PATH=/api/v1/health
ENV AWS_LWA_ASYNC_INIT=true
```

| 設定 | 意図 |
|---|---|
| `AWS_LWA_PORT=8080` | `application.conf` の `ktor.deployment.port` に合わせる |
| `AWS_LWA_READINESS_CHECK_PATH=/api/v1/health` | 既存のヘルスチェックパスを流用（docker-composeのhealthcheckと同じ） |
| `AWS_LWA_ASYNC_INIT=true` | JVMの初期化がINITフェーズの10秒制限を超えても最初のinvokeに持ち越せる |

`EXPOSE 8080` は EC2/docker-compose で意味を持つため維持している（Lambdaでは無視される）。

## バージョン選定

計画書の暫定値 `0.9.1` から **`v1.0.1`**（2026-05-28リリース）に更新した。GitHub releases で最新安定版（prerelease でない）であることを確認済み。`latest` は使わず固定している。

### 環境変数名の確認

v1.0.1 時点の README で `AWS_LWA_` プレフィックス付きが正式名であることを確認した。プレフィックスなしの旧名（`PORT` / `READINESS_CHECK_PATH`）はフォールバックとして残っているが**非推奨で v2.0 で削除予定**と明記されていたため、新しい名前を採用している。

## 検証

### マルチアーキでのアダプタ解決（最重要）

このリポジトリは既に `linux/amd64,linux/arm64` のマルチアーキビルド。`COPY --from` がターゲットプラットフォームに応じて正しいバイナリを解決するかを実測で確認した。

両プラットフォームでビルドし、`docker create` + `docker cp` でバイナリを取り出して `file` で検証:

```
amd64: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, stripped
arm64: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, stripped
```

アダプタイメージ自体が manifest list で `linux/amd64` と `linux/arm64` の両方を持つことも別途確認済み。

### EC2/docker-compose での従来通りの動作

```
$ curl http://0.0.0.0:8080/api/v1/health
{"description":"OK","version":"v1-202607251445+7b721e9c","databaseType":"mysql"}
```

- amd64イメージで `docker compose up` → HTTP 200
- arm64イメージのネイティブ実行 → HTTP 200
- コンテナ内に `/opt/extensions/lambda-adapter` は存在するが、curl が Ktor から直接応答していることから**Lambda外では拡張が起動していない**ことを確認

### イメージサイズの増分（実測）

| | バイト |
|---|---|
| 追加前 | 402,201,349 |
| 追加後 | 405,486,141 |
| **差分** | **約3.13MB**（アダプタ本体は約2.88MB） |

想定の「数MB程度」通り。

### その他

- `./gradlew clean installDist` 成功

## レビュー観点

- アダプタのバージョン固定方針（`1.0.1` 固定 / `latest` 不使用）
- 環境変数名が v1.0.1 の正式名であること
- `EXPOSE 8080` を残す判断
- マルチアーキでのバイナリ解決の検証方法が十分か

## 次のフェーズ

フェーズ7 で、このイメージを使う Lambda 関数とテスト用 API Gateway を構築し、**コールドスタートを計測する判断ゲート**にかける。

## チェックリスト

- [x] 両アーキテクチャでイメージがビルドできる
- [x] 両アーキテクチャで正しいアダプタバイナリが入る
- [x] docker-compose で従来通り起動しヘルスチェックが通る
- [x] アダプタのバージョンを固定している
- [ ] レビュー完了

Related: Lambda Migration Phase 6

🤖 Generated with [Claude Code](https://claude.com/claude-code)
