### PR TITLE
[Lambda Migration] Phase 3: DBマイグレーションを起動時処理から分離

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -36,7 +36,9 @@ tasks.register("generateBuildConfig") {
 
 application {
     if (System.getProperties().getProperty("cli") != null) {
-        mainClass.set("com.github.hmiyado.kottage.cli.CliEntrypoint")
+        // CliEntrypoint lives in the `application` package (moved from `cli` previously);
+        // keep this in sync if it moves again, since it is a plain string reference.
+        mainClass.set("com.github.hmiyado.kottage.application.CliEntrypoint")
     } else {
         mainClass.set("io.ktor.server.netty.EngineMain")
     }

--- a/backend/src/main/kotlin/com/github/hmiyado/kottage/application/Application.kt
+++ b/backend/src/main/kotlin/com/github/hmiyado/kottage/application/Application.kt
@@ -1,6 +1,7 @@
 package com.github.hmiyado.kottage.application
 
 import com.github.hmiyado.kottage.application.configuration.DevelopmentConfiguration
+import com.github.hmiyado.kottage.application.configuration.MigrationConfiguration
 import com.github.hmiyado.kottage.application.plugins.CustomHeaders
 import com.github.hmiyado.kottage.application.plugins.authentication.admin
 import com.github.hmiyado.kottage.application.plugins.authentication.oidcGoogle
@@ -12,6 +13,7 @@ import com.github.hmiyado.kottage.application.plugins.hook.requestHook
 import com.github.hmiyado.kottage.application.plugins.initializeKoinModules
 import com.github.hmiyado.kottage.application.plugins.sessions
 import com.github.hmiyado.kottage.application.plugins.statuspages.statusPages
+import com.github.hmiyado.kottage.repository.connectDatabaseWithoutMigration
 import com.github.hmiyado.kottage.repository.initializeDatabase
 import com.github.hmiyado.kottage.route.routing
 import io.ktor.http.HttpHeaders
@@ -30,7 +32,15 @@ fun Application.main() {
     install(Koin) {
         initializeKoinModules(this@main.environment)
     }
-    initializeDatabase(get())
+    // Migration can be run as a separate step before deploy (see CliEntrypoint's `migrate`
+    // subcommand) so it doesn't have to happen on every cold start (Lambda migration phase3).
+    // Either way the app still needs a working DB connection, so connectDatabaseWithoutMigration
+    // is used when startup migration is skipped.
+    if (this@main.get<MigrationConfiguration>().runOnStartup) {
+        initializeDatabase(get())
+    } else {
+        connectDatabaseWithoutMigration(get())
+    }
     install(CallLogging)
     defaultHeaders()
     install(CORS) {

--- a/backend/src/main/kotlin/com/github/hmiyado/kottage/application/CliEntrypoint.kt
+++ b/backend/src/main/kotlin/com/github/hmiyado/kottage/application/CliEntrypoint.kt
@@ -1,23 +1,35 @@
 package com.github.hmiyado.kottage.application
 
+import com.github.hmiyado.kottage.application.configuration.provideApplicationConfigurationModule
 import com.github.hmiyado.kottage.repository.Migration
-import io.ktor.server.engine.CommandLineConfig
+import com.typesafe.config.ConfigFactory
+import io.ktor.server.config.HoconApplicationConfig
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.get
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
+import org.slf4j.LoggerFactory
+import kotlin.system.exitProcess
 
 object CliEntrypoint : KoinComponent {
+    private val logger = LoggerFactory.getLogger("cli")
+
     @JvmStatic
     fun main(args: Array<String>) {
-        val commandLineConfig =
-            CommandLineConfig(
-                arrayOf("-config=src/main/resources/application.conf"),
-            )
+        // ConfigFactory.load() resolves application.conf from the classpath the same way
+        // Ktor's EngineMain does for the server, including ${?ENV_VAR} substitutions. This
+        // works both from `./gradlew run` (classes on classpath) and from the packaged
+        // distribution/jar, unlike a hardcoded file path relative to the working directory.
+        val config = HoconApplicationConfig(ConfigFactory.load())
         startKoin {
-//            initializeKoinModules(commandLineConfig)
+            modules(provideApplicationConfigurationModule(config))
         }
         when (args.firstOrNull()) {
+            // Standalone entrypoint for running Flyway migrations without booting the
+            // Ktor application (Lambda migration phase3: decouple migration from app startup).
+            // Intended to be run as a one-off step before deployment. Exit code reflects
+            // success/failure so it can gate a CI pipeline.
+            "migrate" -> migrate()
             "database" ->
                 when (args.getOrNull(1)) {
                     "info" -> Migration(get()).info()
@@ -29,5 +41,14 @@ object CliEntrypoint : KoinComponent {
             else -> error("Unexpected argument: ${args.joinToString()}")
         }
         stopKoin()
+    }
+
+    private fun migrate() {
+        runCatching { Migration(get()).migrate() }
+            .onFailure { e ->
+                logger.error("migration failed: {}", e.message, e)
+                exitProcess(1)
+            }
+        exitProcess(0)
     }
 }

--- a/backend/src/main/kotlin/com/github/hmiyado/kottage/application/configuration/ApplicationConfigurationModule.kt
+++ b/backend/src/main/kotlin/com/github/hmiyado/kottage/application/configuration/ApplicationConfigurationModule.kt
@@ -25,6 +25,16 @@ fun provideApplicationConfigurationModule(config: ApplicationConfig): Module =
             )
         }
         single {
+            val runOnStartup =
+                config.property("ktor.migration.runOnStartup").getString().toBooleanStrictOrNull()
+            MigrationConfiguration(
+                // Default to true for local dev convenience and to preserve current EC2
+                // behavior. Only set to false where migrations are run as a separate step
+                // (e.g. Lambda deployments, see delivery.yml).
+                runOnStartup = runOnStartup ?: true,
+            )
+        }
+        single {
             AuthenticationConfiguration(
                 adminCredential =
                     UserPasswordCredential(

--- a/backend/src/main/kotlin/com/github/hmiyado/kottage/application/configuration/MigrationConfiguration.kt
+++ b/backend/src/main/kotlin/com/github/hmiyado/kottage/application/configuration/MigrationConfiguration.kt
@@ -1,0 +1,5 @@
+package com.github.hmiyado.kottage.application.configuration
+
+data class MigrationConfiguration(
+    val runOnStartup: Boolean,
+)

--- a/backend/src/main/kotlin/com/github/hmiyado/kottage/repository/Database.kt
+++ b/backend/src/main/kotlin/com/github/hmiyado/kottage/repository/Database.kt
@@ -1,11 +1,12 @@
 package com.github.hmiyado.kottage.repository
 
 import com.github.hmiyado.kottage.application.configuration.DatabaseConfiguration
+import org.jetbrains.exposed.v1.jdbc.Database
 import org.slf4j.LoggerFactory
 
-fun initializeDatabase(databaseConfiguration: DatabaseConfiguration) {
-    val logger = LoggerFactory.getLogger("Application")
+private val logger = LoggerFactory.getLogger("Application")
 
+fun initializeDatabase(databaseConfiguration: DatabaseConfiguration) {
     when (databaseConfiguration) {
         DatabaseConfiguration.Memory -> {
             logger.debug("database is successfully connected to memory")
@@ -41,3 +42,46 @@ fun initializeDatabase(databaseConfiguration: DatabaseConfiguration) {
         }
     }
 }
+
+/**
+ * Establishes the Exposed DB connection without running Flyway migrations.
+ *
+ * `initializeDatabase` above establishes the connection as a side effect of building the
+ * `Migration`/Flyway instance. When startup migrations are disabled (`RUN_MIGRATION_ON_STARTUP`,
+ * see Lambda migration phase3), the app still needs a working Exposed connection to serve
+ * requests even though migrations are run separately (see CliEntrypoint's `migrate` subcommand).
+ */
+fun connectDatabaseWithoutMigration(databaseConfiguration: DatabaseConfiguration) {
+    when (databaseConfiguration) {
+        DatabaseConfiguration.Memory -> {
+            logger.debug("database is successfully connected to memory")
+        }
+        is DatabaseConfiguration.Postgres -> {
+            throw IllegalStateException("todo postgres connection")
+        }
+        is DatabaseConfiguration.MySql -> {
+            databaseConfiguration.connect()
+            logger.debug("database is successfully connected to mysql (startup migration skipped)")
+        }
+    }
+}
+
+/** Builds the JDBC URL for a MySQL/TiDB connection, applying SSL params for the given sslMode. */
+fun DatabaseConfiguration.MySql.jdbcUrl(): String {
+    val sslParams =
+        when (sslMode.uppercase()) {
+            "REQUIRED" -> "sslMode=REQUIRED&enabledTLSProtocols=TLSv1.2,TLSv1.3"
+            "DISABLED" -> "useSSL=false&allowPublicKeyRetrieval=true"
+            else -> "useSSL=false&allowPublicKeyRetrieval=true"
+        }
+    return "jdbc:mysql://$host:$port/$name?$sslParams"
+}
+
+/** Registers this configuration as Exposed's default database connection. */
+fun DatabaseConfiguration.MySql.connect(): Database =
+    Database.connect(
+        url = jdbcUrl(),
+        driver = "com.mysql.cj.jdbc.Driver",
+        user = user,
+        password = password,
+    )

--- a/backend/src/main/kotlin/com/github/hmiyado/kottage/repository/Migration.kt
+++ b/backend/src/main/kotlin/com/github/hmiyado/kottage/repository/Migration.kt
@@ -9,7 +9,6 @@ import com.github.hmiyado.kottage.repository.users.admins.Admins
 import org.flywaydb.core.Flyway
 import org.flywaydb.core.api.exception.FlywayValidateException
 import org.flywaydb.core.api.output.MigrateResult
-import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.SchemaUtils
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.slf4j.Logger
@@ -106,29 +105,13 @@ class Migration(
         }
 
         private fun DatabaseConfiguration.MySql.init(): Flyway {
-            // SSL設定をsslModeに応じて動的に変更
-            val sslParams =
-                when (sslMode.uppercase()) {
-                    "REQUIRED" -> "sslMode=REQUIRED&enabledTLSProtocols=TLSv1.2,TLSv1.3"
-                    "DISABLED" -> "useSSL=false&allowPublicKeyRetrieval=true"
-                    else -> "useSSL=false&allowPublicKeyRetrieval=true"
-                }
-
-            // ポート番号を動的に使用
-            val url = "jdbc:mysql://$host:$port/$name?$sslParams"
-
             val flyway =
                 Flyway
                     .configure()
                     .baselineOnMigrate(true)
-                    .dataSource(url, user, password)
+                    .dataSource(jdbcUrl(), user, password)
                     .load()
-            Database.connect(
-                url = url,
-                driver = "com.mysql.cj.jdbc.Driver",
-                user = user,
-                password = password,
-            )
+            connect()
             return flyway
         }
     }

--- a/backend/src/main/resources/application.conf
+++ b/backend/src/main/resources/application.conf
@@ -29,6 +29,12 @@ ktor {
       sslMode = ${?MYSQL_SSL_MODE}
     }
   }
+  migration {
+    # Default true: local dev convenience and unchanged EC2 behavior.
+    # Set to false where migrations run as a separate step (e.g. Lambda).
+    runOnStartup = true
+    runOnStartup = ${?RUN_MIGRATION_ON_STARTUP}
+  }
   authentication {
     admin {
       name = "admin"


### PR DESCRIPTION
## 概要

Lambda移行プロジェクト フェーズ3: DBマイグレーションをアプリ起動時処理から**分離できるようにする**。

計画書: `docs/projects/lambda/migration-plan.md` のフェーズ3

**このPRは能力の追加のみで、パイプラインの挙動は一切変えない。** 理由は下記「なぜCIにマイグレーションを入れないか」を参照。

## なぜ必要か

`Application.kt` の `initializeDatabase(get())` により Flyway マイグレーションが**アプリ起動時に実行される**。Lambdaではコールドスタートごとに走ることになり、コールドスタート時間が伸びるうえ、同時起動時の競合リスクが残る。

## 変更内容

### 1. `migrate` サブコマンドの追加

```sh
./gradlew run -Dcli=true --args="migrate"
# または配布物から
build/install/kottage/bin/kottage migrate
```

接続先は `MYSQL_HOST` / `MYSQL_PORT` / `MYSQL_DATABASE` / `MYSQL_USER` / `MYSQL_PASSWORD` / `MYSQL_SSL_MODE` で指定。成功時 exit 0、失敗時 exit 1。

### 2. 起動時マイグレーションを `RUN_MIGRATION_ON_STARTUP` でガード

`application.conf` の `ktor.migration.runOnStartup`（**デフォルト `true`**）にバインド。デフォルトが `true` なので、**ローカル開発と現行EC2の挙動は変わらない**。本番Lambdaでのみ `false` を設定する運用にする。

## なぜCIにマイグレーションを入れないか（当初案からの変更）

当初は `delivery.yml` にデプロイ前マイグレーションステップを入れる計画だったが、**取りやめた**。

### 理由1: 現行EC2はダウンタイムでアトミック性を得ている

```
docker compose down      ← アプリが止まる
  → 起動時マイグレーション
  → 新スキーマでアプリ起動
```

止まっている間に移行するので、旧コードが新スキーマに触る瞬間がない。CIでマイグレーションすると、この性質が失われる。

### 理由2: 窓が「無限」になる

`delivery.yml` は**イメージをpublishするだけでデプロイステップを持たない**（EC2への反映は手作業）。実測でDeploy Backendジョブは2分48秒だが、実際の窓は「誰かが手でEC2を更新するまで」であり、数時間にもなりうる。その間ずっと旧アプリが新スキーマ相手に動く。

### 理由3: DB認証情報をCIに置く必要がなくなる

当初案では `MYSQL_*` の6つのGitHub Secretsが新規に必要で、**CIから本番DBに到達できる**状態になるはずだった。ワークフローを実行できる人の権限がそのままDBアクセス権になる。分離を先送りすることで、この判断も先送りできる。

### いつ分離するか

フェーズ7・8（Lambda移行）で設計する。そこでは窓を秒単位に縮められる:

```
イメージpush
  → マイグレーション用Lambdaを OIDC で invoke   ← DB認証情報はAWS内に留まる
  → PublishVersion + エイリアス切り替え        ← 新規リクエストは即座に新バージョンへ
```

なお、稼働中のサービスがある限り**完全なアトミック性は原理的に不可能**なので、本質的な対策は expand/contract（後方互換なマイグレーション）の規律になる。フェーズ7で計画書に明記する。

## 作業中に見つかった既存バグ（修正が必須だったもの）

### CLIがこれまで一度も動作していなかった

`build.gradle.kts` の `mainClass` が `com.github.hmiyado.kottage.cli.CliEntrypoint` を指していたが、実ファイルは過去のリネームで `.../application/CliEntrypoint.kt`（パッケージ `...kottage.application`）に移動済みだった。さらに `CliEntrypoint.kt` 内の `initializeKoinModules(...)` 呼び出しがコメントアウトされたままで、Koinに何も登録されていなかった。

**つまり既存の `database migrate/info/baseline/statement` は一度も動いたことがない状態だった。**

### `initializeDatabase()` の副作用でDB接続が確立されていた（重要）

`Migration` の初期化処理が Flyway の設定と**同時に Exposed の `Database.connect()` を呼んでいた**。

```
initializeDatabase()
  └─ Migration(config)      ← ここで Database.connect() が走る（副作用）
       └─ migrate()         ← Flyway 本体
```

素直に `RUN_MIGRATION_ON_STARTUP=false` で `initializeDatabase()` 全体をスキップすると、**マイグレーションだけでなくDB接続そのものが確立されず、アプリは起動してヘルスチェックも通るのに最初のクエリでクラッシュする**。実機で再現を確認した。

対処として接続ロジックを `Database.kt` に切り出し、マイグレーションを飛ばす場合でも `connectDatabaseWithoutMigration()` で接続だけは必ず張るようにした。

**JDBC URL の構築ロジックは一字一句そのまま移動しており、`sslParams` の分岐も含めて振る舞いは変わらない**（TiDB の TLS 設定に影響しないことをレビュー時に確認済み）。`Migration` 側も同じ `jdbcUrl()` / `connect()` を使うよう統一した。

これを見逃していたら、フェーズ7でLambdaに `RUN_MIGRATION_ON_STARTUP=false` を設定した瞬間に「ヘルスチェックは通るのに実リクエストで落ちる」という切り分けの難しい壊れ方をしていた。

## テスト

`RUN_MIGRATION_ON_STARTUP` の3パターンを、一時的なマーカーマイグレーション（検証後削除済み）でDBへの実反映を見て確認:

| 設定 | 結果 |
|---|---|
| `false` | 起動・`/api/v1/health`・`/api/v1/entries` とも200。**新規マイグレーションは適用されない**（`flyway_schema_history` が変化しない） |
| 未設定 | 従来通り起動時に適用される |
| `true` | 起動時に適用される |

- `migrate` サブコマンド: docker composeのMySQLに対して成功（exit 0、テーブル作成を確認）。パスワード誤りで exit 1 も確認
- `installDist` の配布物からも同様に動作確認
- `./gradlew build -x karate:test` / `ktlintCheck` 成功

## スコープ外として残した既存バグ

`logback.xml` の `<if>` 条件分岐内の appender-ref が機能しておらず（`Appender named [DEVELOPMENT] not referenced` の警告が出る）、`root` ロガーにappenderが結び付いていない。**通常起動でもCLIでも `logger.info/error` の出力が一切コンソールに出ない。**

本PRの変更とは無関係の既存バグ。EC2本番でも同様にログが出ていない可能性があり、別途調査を推奨する。この影響で本PRの検証は「ログで確認」ではなくDBの実テーブル変化で行っている。

## レビュー観点

- `connectDatabaseWithoutMigration()` の切り出しが妥当か（JDBC URL構築の同一性）
- `RUN_MIGRATION_ON_STARTUP` のデフォルトを `true` にする判断
- CLI関連の既存バグ修正がスコープとして許容範囲か

## チェックリスト

- [x] ビルドとテストがパスする
- [x] `RUN_MIGRATION_ON_STARTUP` の3パターンを実機検証
- [x] `migrate` サブコマンドが単体で成功し、失敗時に非ゼロで終了する
- [x] JDBC URL構築の振る舞いが変わっていない
- [x] パイプラインの挙動を変えていない（GitHub Secretsの追加設定は不要）
- [ ] レビュー完了

Related: Lambda Migration Phase 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)
