### PR TITLE
[Lambda Migration] Phase 2: セッション/OAuth state のステートレス化

### DIFF
--- a/backend/.ci.env
+++ b/backend/.ci.env
@@ -1,2 +1,4 @@
 ADMIN_NAME=admin
 ADMIN_PASSWORD=admin
+# Local/CI only. Generate a real one with `openssl rand -hex 32` for any shared environment.
+SESSION_SIGN_KEY=de52d58120f50ea81c957be973f167047f918357fc39002054baaebe2823a77c

--- a/backend/karate/src/test/kotlin/kottage/users/users.feature
+++ b/backend/karate/src/test/kotlin/kottage/users/users.feature
@@ -16,7 +16,10 @@ Feature: users
     And method POST
     Then status 201
     And match response == {id: '#number', screenName: '#(screenName)'}
-    And match responseCookies.user_session contains { value: '#regex [0-9a-z]+', httponly: false}
+    # The session is stateless: the cookie carries the URI-encoded payload followed by
+    # %2F (an encoded '/') and the 64 hex chars of its HMAC-SHA256 signature, rather than
+    # an opaque server-side id. httpOnly is on because no JavaScript reads these cookies.
+    And match responseCookies.user_session contains { value: '#regex .+%2F[0-9a-f]{64}', httponly: true}
     * def location = responseHeaders['Location'][0]
   # PATCH /users/:id
     Given url location
@@ -42,7 +45,7 @@ Feature: users
     And method POST
     Then status 200
     And match response == {id: '#number', screenName: '#(newScreenName)', accountLinks: [{service:"Google", linking: false}]}
-    And match responseCookies.user_session contains { value: '#regex [0-9a-z]+'}
+    And match responseCookies.user_session contains { value: '#regex .+%2F[0-9a-f]{64}'}
   # GET /users/current
     Given url baseUrl + '/users/current'
     And method GET

--- a/backend/src/main/kotlin/com/github/hmiyado/kottage/application/Application.kt
+++ b/backend/src/main/kotlin/com/github/hmiyado/kottage/application/Application.kt
@@ -24,7 +24,6 @@ import io.ktor.server.auth.Authentication
 import io.ktor.server.plugins.autohead.AutoHeadResponse
 import io.ktor.server.plugins.calllogging.CallLogging
 import io.ktor.server.plugins.cors.routing.CORS
-import org.koin.core.qualifier.named
 import org.koin.ktor.ext.get
 import org.koin.ktor.plugin.Koin
 
@@ -66,7 +65,7 @@ fun Application.main() {
     install(Authentication) {
         admin(this@main.get(), this@main.get(), this@main.get())
         users(this@main.get())
-        oidcGoogle(this@main.get(), this@main.get(), this@main.get(), this@main.get(), this@main.get(named("pre-oauth-states")))
+        oidcGoogle(this@main.get(), this@main.get(), this@main.get(), this@main.get(), this@main.get())
     }
     sessions()
     clientSession()

--- a/backend/src/main/kotlin/com/github/hmiyado/kottage/application/configuration/ApplicationConfigurationModule.kt
+++ b/backend/src/main/kotlin/com/github/hmiyado/kottage/application/configuration/ApplicationConfigurationModule.kt
@@ -51,6 +51,11 @@ fun provideApplicationConfigurationModule(config: ApplicationConfig): Module =
                 defaultRedirectUrl = config.property("ktor.authentication.oauth.google.defaultRedirectUrl").getString(),
             )
         }
+        single(createdAtStart = true) {
+            // Fails fast at startup if unset/too short, rather than silently falling back to an
+            // insecure default. See SessionSignKey's kdoc for why this key must exist.
+            SessionSignKey.fromHex(config.propertyOrNull("ktor.authentication.sessionSignKey")?.getString())
+        }
         single {
             Health.Version(BuildConfig.version)
         }

--- a/backend/src/main/kotlin/com/github/hmiyado/kottage/application/configuration/SessionSignKey.kt
+++ b/backend/src/main/kotlin/com/github/hmiyado/kottage/application/configuration/SessionSignKey.kt
@@ -1,0 +1,60 @@
+package com.github.hmiyado.kottage.application.configuration
+
+/**
+ * The HMAC key used to sign stateless sessions (cookie<UserSession>/cookie<ClientSession>/
+ * header<CsrfTokenSession>), the stateless OAuth `state` token, and the OAuth nonce manager.
+ *
+ * Sessions used to be kept in server-side memory (`SessionStorageMemory`), so cookies only ever
+ * carried an opaque, meaningless id and signing was unnecessary. Once the app runs on Lambda,
+ * multiple execution environments can be involved within a single session's lifetime, so the
+ * cookie itself must become the credential. Without a signature, a client could forge or tamper
+ * with it; without a mandatory key, a misconfigured production deployment would silently accept
+ * an insecure default. Hence this type fails fast instead of falling back to a default value.
+ */
+class SessionSignKey(
+    val bytes: ByteArray,
+) {
+    companion object {
+        /**
+         * 128 bit (32 hex chars) is the practical floor for an HMAC-SHA256 key. The documented
+         * generation command (`openssl rand -hex 32`) produces 256 bit (64 hex chars); this is
+         * intentionally looser so it only rejects keys that are clearly too weak.
+         */
+        const val MIN_HEX_LENGTH = 32
+
+        fun fromHex(hex: String?): SessionSignKey {
+            val value = hex?.trim()
+            if (value.isNullOrEmpty()) {
+                throw SessionSignKeyConfigurationException(
+                    "SESSION_SIGN_KEY is not set. Generate one with `openssl rand -hex 32` and set it as an environment variable.",
+                )
+            }
+            if (value.length < MIN_HEX_LENGTH) {
+                throw SessionSignKeyConfigurationException(
+                    "SESSION_SIGN_KEY is too short (${value.length} hex chars, minimum is $MIN_HEX_LENGTH). " +
+                        "Generate one with `openssl rand -hex 32`.",
+                )
+            }
+            val bytes =
+                try {
+                    decodeHex(value)
+                } catch (e: IllegalArgumentException) {
+                    throw SessionSignKeyConfigurationException("SESSION_SIGN_KEY must be a hex string.", e)
+                }
+            return SessionSignKey(bytes)
+        }
+
+        private fun decodeHex(hex: String): ByteArray {
+            require(hex.length % 2 == 0) { "hex string must have an even length" }
+            return ByteArray(hex.length / 2) { i ->
+                val index = i * 2
+                hex.substring(index, index + 2).toInt(16).toByte()
+            }
+        }
+    }
+}
+
+class SessionSignKeyConfigurationException(
+    message: String,
+    cause: Throwable? = null,
+) : Exception(message, cause)

--- a/backend/src/main/kotlin/com/github/hmiyado/kottage/application/plugins/Sessions.kt
+++ b/backend/src/main/kotlin/com/github/hmiyado/kottage/application/plugins/Sessions.kt
@@ -1,45 +1,43 @@
 package com.github.hmiyado.kottage.application.plugins
 
 import com.github.hmiyado.kottage.application.configuration.DevelopmentConfiguration
+import com.github.hmiyado.kottage.application.configuration.SessionSignKey
 import com.github.hmiyado.kottage.application.plugins.authentication.sessionExpiration
 import com.github.hmiyado.kottage.application.plugins.clientsession.ClientSession
 import com.github.hmiyado.kottage.application.plugins.csrf.CsrfTokenSession
 import com.github.hmiyado.kottage.model.UserSession
 import io.ktor.server.application.Application
 import io.ktor.server.application.install
+import io.ktor.server.sessions.SessionTransportTransformerMessageAuthentication
 import io.ktor.server.sessions.Sessions
 import io.ktor.server.sessions.cookie
-import io.ktor.server.sessions.get
 import io.ktor.server.sessions.header
-import io.ktor.server.sessions.set
 import org.koin.ktor.ext.get
 
 fun Application.sessions() {
+    // No SessionStorage is registered: the entire (signed) session value round-trips through the
+    // client via cookie/header, so no process holds state that a Lambda recycle could lose.
+    val signKey = get<SessionSignKey>().bytes
+    val isProduction = get<DevelopmentConfiguration>() == DevelopmentConfiguration.Production
     install(Sessions) {
-        cookie<UserSession>("user_session", storage = this@sessions.get()) {
-            cookie.httpOnly = false
+        cookie<UserSession>("user_session") {
+            cookie.httpOnly = true
             cookie.extensions["SameSite"] = "Strict"
-            cookie.secure =
-                when (this@sessions.get<DevelopmentConfiguration>()) {
-                    DevelopmentConfiguration.Development -> false
-                    // todo: secure should be true in production, but infra architecture is not match now (lb -> app is http)
-                    // cors requires https, so that non-secure browser may not be able to get cookie
-                    DevelopmentConfiguration.Production -> false
-                }
+            // Secure only gates the browser -> API Gateway hop, which is HTTPS via ACM. The
+            // internal API Gateway -> app hop is invisible to the browser, so this is safe.
+            cookie.secure = isProduction
             cookie.maxAgeInSeconds = sessionExpiration.seconds
+            transform(SessionTransportTransformerMessageAuthentication(signKey))
         }
-        cookie<ClientSession>("client_session", storage = this@sessions.get()) {
-            cookie.httpOnly = false
+        cookie<ClientSession>("client_session") {
+            cookie.httpOnly = true
             cookie.extensions["SameSite"] = "Strict"
-            cookie.secure =
-                when (this@sessions.get<DevelopmentConfiguration>()) {
-                    DevelopmentConfiguration.Development -> false
-                    // todo: secure should be true in production, but infra architecture is not match now (lb -> app is http)
-                    // cors requires https, so that non-secure browser may not be able to get cookie
-                    DevelopmentConfiguration.Production -> false
-                }
+            cookie.secure = isProduction
             cookie.maxAgeInSeconds = sessionExpiration.seconds
+            transform(SessionTransportTransformerMessageAuthentication(signKey))
         }
-        header<CsrfTokenSession>(CustomHeaders.X_CSRF_TOKEN, storage = this@sessions.get())
+        header<CsrfTokenSession>(CustomHeaders.X_CSRF_TOKEN) {
+            transform(SessionTransportTransformerMessageAuthentication(signKey))
+        }
     }
 }

--- a/backend/src/main/kotlin/com/github/hmiyado/kottage/application/plugins/authentication/AuthenticationAdmin.kt
+++ b/backend/src/main/kotlin/com/github/hmiyado/kottage/application/plugins/authentication/AuthenticationAdmin.kt
@@ -36,6 +36,9 @@ fun AuthenticationConfig.admin(
     session<UserSession>(name = "admin") {
         validate {
             val session = this.sessions.get<UserSession>() ?: return@validate null
+            // See AuthenticationUser.kt: the signature is verified already, but expiresAt is
+            // part of the signed payload and must still be checked explicitly.
+            if (session.expiresAt < System.currentTimeMillis()) return@validate null
             if (adminsService.isAdmin(session.id)) {
                 val user = usersService.getUser(session.id) ?: return@validate null
                 UserPrincipal.Admin(user)

--- a/backend/src/main/kotlin/com/github/hmiyado/kottage/application/plugins/authentication/AuthenticationModule.kt
+++ b/backend/src/main/kotlin/com/github/hmiyado/kottage/application/plugins/authentication/AuthenticationModule.kt
@@ -1,28 +1,36 @@
 package com.github.hmiyado.kottage.application.plugins.authentication
 
-import io.ktor.server.sessions.SessionStorage
-import io.ktor.server.sessions.SessionStorageMemory
+import com.github.hmiyado.kottage.application.configuration.SessionSignKey
+import com.github.hmiyado.kottage.model.UserSession
 import io.ktor.util.NonceManager
-import io.ktor.util.StatelessHmacNonceManager
-import io.ktor.util.generateNonce
-import org.koin.core.qualifier.named
 import org.koin.dsl.module
 import java.time.Duration
+import java.time.Instant
 
 val sessionExpiration: Duration = Duration.ofDays(7)
 
+// Matches the timeout previously passed to StatelessHmacNonceManager(timeoutMillis = 180_000).
+val oauthStateExpiration: Duration = Duration.ofMinutes(3)
+
+fun newUserSession(id: Long): UserSession =
+    UserSession(
+        id = id,
+        // Absolute expiration, fixed at sign-in time and never refreshed: a sliding expiration
+        // would let a leaked token stay valid indefinitely as long as it keeps being used.
+        expiresAt = Instant.now().plus(sessionExpiration).toEpochMilli(),
+    )
+
 val authenticationModule =
     module {
-        factory<SessionStorage> {
-            SessionStorageMemory()
-        }
-        single(named("pre-oauth-states")) {
-            mutableMapOf<String, PreOauthState>()
+        single {
+            OauthStateCodec(get<SessionSignKey>().bytes)
         }
         single<NonceManager> {
-            StatelessHmacNonceManager(
-                key = generateNonce().toByteArray(),
-                timeoutMillis = 180_000,
-            )
+            // Previously StatelessHmacNonceManager(key = generateNonce()...): a new random key
+            // per process, so an OAuth flow that started before a restart/recycle and completed
+            // after it would always fail nonce verification. Using SESSION_SIGN_KEY fixes that
+            // (a real bug, not just a Lambda-readiness concern) as a side effect of going
+            // stateless.
+            OauthStateNonceManager(get())
         }
     }

--- a/backend/src/main/kotlin/com/github/hmiyado/kottage/application/plugins/authentication/AuthenticationOidcGoogle.kt
+++ b/backend/src/main/kotlin/com/github/hmiyado/kottage/application/plugins/authentication/AuthenticationOidcGoogle.kt
@@ -13,13 +13,14 @@ import io.ktor.server.sessions.sessions
 import io.ktor.util.NonceManager
 import io.ktor.util.generateNonce
 import kotlinx.coroutines.runBlocking
+import java.time.Instant
 
 fun AuthenticationConfig.oidcGoogle(
     httpClient: HttpClient,
     oauthGoogle: OauthGoogle,
     oauthGoogleRepository: OauthGoogleRepository,
     nonceManager: NonceManager,
-    preOauthStates: MutableMap<String, PreOauthState>,
+    oauthStateCodec: OauthStateCodec,
 ) {
     oauth("oidc-google") {
         val config =
@@ -31,10 +32,26 @@ fun AuthenticationConfig.oidcGoogle(
             OAuthServerSettings.OAuth2ServerSettings(
                 name = "google",
                 authorizeUrl = config.authorizationEndpoint,
-                authorizeUrlInterceptor = interceptor@{
-                    val state = parameters["state"] ?: return@interceptor
-                    val nonce = preOauthStates[state]?.nonce ?: return@interceptor
-                    parameters.append("nonce", nonce)
+                authorizeUrlInterceptor = {
+                    // Ktor already appended a `state` built from nonceManager.newNonce() to
+                    // `parameters` before this interceptor runs; it is replaced here with a
+                    // self-contained, HMAC-signed token carrying what the callback needs
+                    // (redirectUrl / userId / OIDC nonce), since a server-side map keyed by the
+                    // old opaque state cannot survive the authorize and callback requests landing
+                    // on two different Lambda execution environments.
+                    val oidcNonce = generateNonce()
+                    val preOauthState =
+                        PreOauthState(
+                            redirectUrl = it.queryParameters["redirectUrl"] ?: oauthGoogle.defaultRedirectUrl,
+                            userId =
+                                it.call.sessions
+                                    .get<UserSession>()
+                                    ?.id,
+                            nonce = oidcNonce,
+                            expiresAt = Instant.now().plus(oauthStateExpiration).toEpochMilli(),
+                        )
+                    parameters.set("state", oauthStateCodec.encode(preOauthState))
+                    parameters.append("nonce", oidcNonce)
                 },
                 accessTokenUrl = config.tokenEndpoint,
                 requestMethod = HttpMethod.Post,
@@ -44,14 +61,7 @@ fun AuthenticationConfig.oidcGoogle(
                 nonceManager = nonceManager,
                 // response_type=code by default
                 extraAuthParameters = listOf(),
-                onStateCreated = { call, state ->
-                    preOauthStates[state] =
-                        PreOauthState(
-                            redirectUrl = call.request.queryParameters["redirectUrl"] ?: oauthGoogle.defaultRedirectUrl,
-                            userId = call.sessions.get<UserSession>()?.id,
-                            nonce = generateNonce(),
-                        )
-                },
+                onStateCreated = { _, _ -> },
             )
         }
         client = httpClient

--- a/backend/src/main/kotlin/com/github/hmiyado/kottage/application/plugins/authentication/AuthenticationUser.kt
+++ b/backend/src/main/kotlin/com/github/hmiyado/kottage/application/plugins/authentication/AuthenticationUser.kt
@@ -11,6 +11,10 @@ fun AuthenticationConfig.users(usersService: UsersService) {
     session<UserSession>(name = "user") {
         validate {
             val session = this.sessions.get<UserSession>() ?: return@validate null
+            // The signature is already verified by SessionTransportTransformerMessageAuthentication
+            // by the time we get here; expiresAt is part of the signed payload, so it still needs
+            // an explicit check since there is no server-side store to have expired it for us.
+            if (session.expiresAt < System.currentTimeMillis()) return@validate null
             val user = usersService.getUser(session.id) ?: return@validate null
             UserPrincipal.User(user)
         }

--- a/backend/src/main/kotlin/com/github/hmiyado/kottage/application/plugins/authentication/OauthStateCodec.kt
+++ b/backend/src/main/kotlin/com/github/hmiyado/kottage/application/plugins/authentication/OauthStateCodec.kt
@@ -1,0 +1,85 @@
+package com.github.hmiyado.kottage.application.plugins.authentication
+
+import io.ktor.util.NonceManager
+import io.ktor.util.generateNonce
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import java.security.MessageDigest
+import java.util.Base64
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * Encodes/decodes [PreOauthState] into a self-contained, HMAC-signed token that is embedded
+ * directly in the OAuth `state` parameter sent to Google, instead of being looked up from a
+ * server-side map (`pre-oauth-states`) keyed by an opaque state value.
+ *
+ * `state` is the only part of the OAuth2 authorization request that a spec-compliant provider is
+ * guaranteed to echo back on the callback unchanged; any other data we want back has to ride
+ * inside it. A process-local map cannot survive the authorize and callback requests landing on
+ * two different Lambda execution environments, so the payload itself must be stateless.
+ */
+class OauthStateCodec(
+    private val signKey: ByteArray,
+) {
+    private val base64Encoder = Base64.getUrlEncoder().withoutPadding()
+    private val base64Decoder = Base64.getUrlDecoder()
+
+    fun encode(state: PreOauthState): String {
+        val payload = base64Encoder.encodeToString(Json.encodeToString(state).toByteArray(Charsets.UTF_8))
+        val signature = base64Encoder.encodeToString(hmac(payload))
+        return "$payload.$signature"
+    }
+
+    /**
+     * Verifies the signature and expiration of [token] and decodes it back into a [PreOauthState].
+     * Returns null if the token is malformed, was not signed with [signKey], or has expired.
+     */
+    fun decode(token: String): PreOauthState? {
+        val separatorIndex = token.lastIndexOf('.')
+        if (separatorIndex <= 0 || separatorIndex == token.length - 1) return null
+        val payload = token.substring(0, separatorIndex)
+        val signature = token.substring(separatorIndex + 1)
+        val expectedSignature = base64Encoder.encodeToString(hmac(payload))
+        if (!constantTimeEquals(signature, expectedSignature)) return null
+        val state =
+            runCatching {
+                Json.decodeFromString<PreOauthState>(String(base64Decoder.decode(payload), Charsets.UTF_8))
+            }.getOrNull() ?: return null
+        if (state.expiresAt < System.currentTimeMillis()) return null
+        return state
+    }
+
+    private fun hmac(data: String): ByteArray {
+        val mac = Mac.getInstance(ALGORITHM)
+        mac.init(SecretKeySpec(signKey, ALGORITHM))
+        return mac.doFinal(data.toByteArray(Charsets.UTF_8))
+    }
+
+    private fun constantTimeEquals(
+        a: String,
+        b: String,
+    ): Boolean = MessageDigest.isEqual(a.toByteArray(Charsets.UTF_8), b.toByteArray(Charsets.UTF_8))
+
+    private companion object {
+        const val ALGORITHM = "HmacSHA256"
+    }
+}
+
+/**
+ * Adapts [OauthStateCodec] to Ktor's OAuth2 [NonceManager] contract so the `state` parameter's
+ * signature and expiration are verified before an authorization code is exchanged for a token.
+ *
+ * [newNonce] is effectively unused: Ktor calls it with no request context to build the initial
+ * `state` value, but `authorizeUrlInterceptor` (see `oidcGoogle`) overwrites that value with the
+ * real signed token afterward, since only the interceptor has access to the current call. Only
+ * [verifyNonce] matters here, and it must accept whatever the interceptor produced rather than
+ * whatever [newNonce] returned.
+ */
+class OauthStateNonceManager(
+    private val codec: OauthStateCodec,
+) : NonceManager {
+    override suspend fun newNonce(): String = generateNonce()
+
+    override suspend fun verifyNonce(nonce: String): Boolean = codec.decode(nonce) != null
+}

--- a/backend/src/main/kotlin/com/github/hmiyado/kottage/application/plugins/authentication/PreOauthState.kt
+++ b/backend/src/main/kotlin/com/github/hmiyado/kottage/application/plugins/authentication/PreOauthState.kt
@@ -1,11 +1,18 @@
 package com.github.hmiyado.kottage.application.plugins.authentication
 
+import kotlinx.serialization.Serializable
+
 /**
  * @param redirectUrl specified redirect url
  * @param userId userId or null if not signed in
+ * @param nonce nonce passed to Google and later checked against the OIDC id token's nonce claim
+ * @param expiresAt epoch millis after which this state must be rejected, preventing an old
+ * `state` value (and the authorize URL it was embedded in) from being replayed
  */
+@Serializable
 data class PreOauthState(
     val redirectUrl: String,
     val userId: Long?,
     val nonce: String,
+    val expiresAt: Long,
 )

--- a/backend/src/main/kotlin/com/github/hmiyado/kottage/model/UserSession.kt
+++ b/backend/src/main/kotlin/com/github/hmiyado/kottage/model/UserSession.kt
@@ -2,7 +2,14 @@ package com.github.hmiyado.kottage.model
 
 import kotlinx.serialization.Serializable
 
+/**
+ * @param expiresAt epoch millis after which this session must be treated as unauthenticated.
+ * Signed together with [id] so a client cannot extend its own session by tampering with the
+ * cookie's `maxAge`, and so a stolen-but-not-yet-expired token cannot be replayed forever now
+ * that no server-side store can revoke it.
+ */
 @Serializable
 data class UserSession(
     val id: Long = 0,
+    val expiresAt: Long = 0,
 )

--- a/backend/src/main/kotlin/com/github/hmiyado/kottage/route/RouteModule.kt
+++ b/backend/src/main/kotlin/com/github/hmiyado/kottage/route/RouteModule.kt
@@ -9,7 +9,6 @@ import com.github.hmiyado.kottage.route.oauth.OauthGoogleLocation
 import com.github.hmiyado.kottage.route.users.UsersAdminsLocation
 import com.github.hmiyado.kottage.route.users.UsersIdLocation
 import com.github.hmiyado.kottage.route.users.UsersLocation
-import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
 val routeModule =
@@ -25,7 +24,7 @@ val routeModule =
                 UsersIdLocation(get()),
                 UsersAdminsLocation(get(), get()),
                 HealthLocation(get()),
-                OauthGoogleLocation(get(), get(), get(), get(), get(named("pre-oauth-states"))),
+                OauthGoogleLocation(get(), get(), get(), get(), get()),
             )
         }
     }

--- a/backend/src/main/kotlin/com/github/hmiyado/kottage/route/oauth/OauthGoogleLocation.kt
+++ b/backend/src/main/kotlin/com/github/hmiyado/kottage/route/oauth/OauthGoogleLocation.kt
@@ -2,9 +2,9 @@ package com.github.hmiyado.kottage.route.oauth
 
 import com.auth0.jwt.interfaces.DecodedJWT
 import com.github.hmiyado.kottage.application.configuration.OauthGoogle
-import com.github.hmiyado.kottage.application.plugins.authentication.PreOauthState
+import com.github.hmiyado.kottage.application.plugins.authentication.OauthStateCodec
+import com.github.hmiyado.kottage.application.plugins.authentication.newUserSession
 import com.github.hmiyado.kottage.model.OidcToken
-import com.github.hmiyado.kottage.model.UserSession
 import com.github.hmiyado.kottage.repository.oauth.OauthGoogleRepository
 import com.github.hmiyado.kottage.repository.users.UserRepository
 import com.github.hmiyado.kottage.route.Router
@@ -26,7 +26,7 @@ class OauthGoogleLocation(
     private val oauthGoogle: OauthGoogle,
     private val oauthGoogleRepository: OauthGoogleRepository,
     private val oauthGoogleService: OauthGoogleService,
-    private val preOauthStates: MutableMap<String, PreOauthState>,
+    private val oauthStateCodec: OauthStateCodec,
 ) : Router {
     override fun addRoute(route: Route) {
         with(route) {
@@ -39,12 +39,7 @@ class OauthGoogleLocation(
 
                 get("/oauth/google/callback") {
                     val principal: OAuthAccessTokenResponse.OAuth2? = call.principal()
-                    val preOauthState =
-                        principal?.state?.let {
-                            val state = preOauthStates[it]
-                            preOauthStates.remove(it)
-                            state
-                        }
+                    val preOauthState = principal?.state?.let { oauthStateCodec.decode(it) }
                     val oidcToken =
                         run {
                             val idToken = principal?.extraParameters?.get("id_token") ?: ""
@@ -65,13 +60,13 @@ class OauthGoogleLocation(
                                 when {
                                     preOauthState?.userId == null -> {
                                         // newly signed in
-                                        call.sessions.set(UserSession(id = existingUser.id))
+                                        call.sessions.set(newUserSession(existingUser.id))
                                         "signIn"
                                     }
 
                                     existingUser.id == preOauthState.userId -> {
                                         // already signed in via oidc user
-                                        call.sessions.set(UserSession(id = existingUser.id))
+                                        call.sessions.set(newUserSession(existingUser.id))
                                         "alreadySignIn"
                                     }
 
@@ -85,7 +80,7 @@ class OauthGoogleLocation(
 
                             preOauthState?.userId == null -> {
                                 val user = usersService.createUserByOidc(oidcToken)
-                                call.sessions.set(UserSession(id = user.id))
+                                call.sessions.set(newUserSession(user.id))
                                 "signUp"
                             }
 

--- a/backend/src/main/kotlin/com/github/hmiyado/kottage/route/users/UsersLocation.kt
+++ b/backend/src/main/kotlin/com/github/hmiyado/kottage/route/users/UsersLocation.kt
@@ -1,5 +1,6 @@
 package com.github.hmiyado.kottage.route.users
 
+import com.github.hmiyado.kottage.application.plugins.authentication.newUserSession
 import com.github.hmiyado.kottage.application.plugins.statuspages.ErrorFactory
 import com.github.hmiyado.kottage.model.User
 import com.github.hmiyado.kottage.model.UserSession
@@ -47,7 +48,7 @@ class UsersLocation(
                         return@usersPost
                     }
                 call.response.header("Location", call.url { this.appendPathSegments("${user.id}") })
-                call.sessions.set(UserSession(id = user.id))
+                call.sessions.set(newUserSession(user.id))
                 call.respond(HttpStatusCode.Created, user.toResponseUser())
             }
 
@@ -68,7 +69,7 @@ class UsersLocation(
                     call.respond(HttpStatusCode.Conflict, ErrorFactory.create409())
                     return@signInPost
                 }
-                call.sessions.set(UserSession(id = user.id))
+                call.sessions.set(newUserSession(user.id))
                 call.respond(HttpStatusCode.OK, user.toResponseDetail())
             }
 

--- a/backend/src/main/resources/application.conf
+++ b/backend/src/main/resources/application.conf
@@ -36,6 +36,8 @@ ktor {
     runOnStartup = ${?RUN_MIGRATION_ON_STARTUP}
   }
   authentication {
+    sessionSignKey = ""
+    sessionSignKey = ${?SESSION_SIGN_KEY}
     admin {
       name = "admin"
       name = ${?ADMIN_NAME}

--- a/backend/src/test/kotlin/com/github/hmiyado/kottage/application/configuration/SessionSignKeyTest.kt
+++ b/backend/src/test/kotlin/com/github/hmiyado/kottage/application/configuration/SessionSignKeyTest.kt
@@ -1,0 +1,47 @@
+package com.github.hmiyado.kottage.application.configuration
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+
+class SessionSignKeyTest :
+    DescribeSpec({
+        describe("fromHex") {
+            it("should decode a valid hex string into bytes") {
+                // 32 hex chars: the minimum accepted length
+                val key = SessionSignKey.fromHex("00ff10" + "00".repeat(13))
+                key.bytes shouldBe byteArrayOf(0x00, 0xff.toByte(), 0x10) + ByteArray(13)
+            }
+
+            it("should accept a real openssl rand -hex 32 style key") {
+                val hex = "a".repeat(64)
+                val key = SessionSignKey.fromHex(hex)
+                key.bytes.size shouldBe 32
+            }
+
+            it("should fail fast when null") {
+                shouldThrow<SessionSignKeyConfigurationException> {
+                    SessionSignKey.fromHex(null)
+                }
+            }
+
+            it("should fail fast when blank") {
+                shouldThrow<SessionSignKeyConfigurationException> {
+                    SessionSignKey.fromHex("   ")
+                }
+            }
+
+            it("should fail fast when shorter than the minimum length") {
+                shouldThrow<SessionSignKeyConfigurationException> {
+                    SessionSignKey.fromHex("ab".repeat(10))
+                }
+            }
+
+            it("should fail fast when not a hex string") {
+                shouldThrow<SessionSignKeyConfigurationException> {
+                    // even length, long enough to pass the length check, but 'g' is not hex
+                    SessionSignKey.fromHex("g".repeat(40))
+                }
+            }
+        }
+    })

--- a/backend/src/test/kotlin/com/github/hmiyado/kottage/application/plugins/authentication/OauthStateCodecTest.kt
+++ b/backend/src/test/kotlin/com/github/hmiyado/kottage/application/plugins/authentication/OauthStateCodecTest.kt
@@ -1,0 +1,87 @@
+package com.github.hmiyado.kottage.application.plugins.authentication
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.runBlocking
+import java.time.Instant
+
+class OauthStateCodecTest :
+    DescribeSpec({
+        val signKey = ByteArray(32) { it.toByte() }
+        val otherSignKey = ByteArray(32) { (it + 1).toByte() }
+
+        fun futureState(userId: Long? = null) =
+            PreOauthState(
+                redirectUrl = "https://miyado.dev/callback",
+                userId = userId,
+                nonce = "some-nonce",
+                expiresAt = Instant.now().plusSeconds(180).toEpochMilli(),
+            )
+
+        describe("encode/decode") {
+            it("should round trip a valid, unexpired state") {
+                val codec = OauthStateCodec(signKey)
+                val state = futureState(userId = 42)
+
+                val token = codec.encode(state)
+                val decoded = codec.decode(token)
+
+                decoded shouldBe state
+            }
+
+            it("should round trip when userId is null (not signed in)") {
+                val codec = OauthStateCodec(signKey)
+                val state = futureState(userId = null)
+
+                codec.decode(codec.encode(state)) shouldBe state
+            }
+        }
+
+        describe("decode") {
+            it("should reject a token signed with a different key") {
+                val token = OauthStateCodec(otherSignKey).encode(futureState())
+
+                OauthStateCodec(signKey).decode(token) shouldBe null
+            }
+
+            it("should reject a tampered payload") {
+                val codec = OauthStateCodec(signKey)
+                val token = codec.encode(futureState())
+                val (payload, signature) = token.split(".", limit = 2)
+                val tampered = "$payload-tampered.$signature"
+
+                codec.decode(tampered) shouldBe null
+            }
+
+            it("should reject an expired token") {
+                val codec = OauthStateCodec(signKey)
+                val expired =
+                    PreOauthState(
+                        redirectUrl = "https://miyado.dev/callback",
+                        userId = null,
+                        nonce = "some-nonce",
+                        expiresAt = Instant.now().minusSeconds(1).toEpochMilli(),
+                    )
+
+                codec.decode(codec.encode(expired)) shouldBe null
+            }
+
+            it("should reject a malformed token") {
+                val codec = OauthStateCodec(signKey)
+
+                codec.decode("not-a-valid-token") shouldBe null
+            }
+
+            it("should verify via the NonceManager adapter") {
+                val codec = OauthStateCodec(signKey)
+                val nonceManager = OauthStateNonceManager(codec)
+                val token = codec.encode(futureState())
+
+                runBlocking {
+                    nonceManager.verifyNonce(token) shouldBe true
+                    nonceManager.verifyNonce("garbage") shouldBe false
+                    (nonceManager.newNonce().isNotEmpty()) shouldBe true
+                }
+            }
+        }
+    })

--- a/backend/src/test/kotlin/com/github/hmiyado/kottage/helper/AuthorizationHelper.kt
+++ b/backend/src/test/kotlin/com/github/hmiyado/kottage/helper/AuthorizationHelper.kt
@@ -22,6 +22,7 @@ import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.just
+import java.time.Duration
 
 class AuthorizationHelper(
     private val usersService: UsersService,
@@ -61,7 +62,8 @@ class AuthorizationHelper(
     ) {
         val session = "this-is-mocked-admin-session"
         coEvery { sessionStorage.write(any(), any()) } just Runs
-        coEvery { sessionStorage.read(any()) } returns UserSession(user.id).toJsonString()
+        coEvery { sessionStorage.read(any()) } returns
+            UserSession(id = user.id, expiresAt = System.currentTimeMillis() + Duration.ofDays(1).toMillis()).toJsonString()
         every { usersService.getUser(user.id) } returns user
         adminsService?.let { service -> every { service.isAdmin(user.id) } returns true }
         builder.headers {

--- a/backend/src/test/kotlin/com/github/hmiyado/kottage/route/RoutingTest.kt
+++ b/backend/src/test/kotlin/com/github/hmiyado/kottage/route/RoutingTest.kt
@@ -1,7 +1,7 @@
 package com.github.hmiyado.kottage.route
 
 import com.github.hmiyado.kottage.application.configuration.OauthGoogle
-import com.github.hmiyado.kottage.application.plugins.authentication.PreOauthState
+import com.github.hmiyado.kottage.application.plugins.authentication.OauthStateCodec
 import com.github.hmiyado.kottage.application.plugins.statuspages.statusPagesModule
 import com.github.hmiyado.kottage.helper.AuthorizationHelper
 import com.github.hmiyado.kottage.openapi.Paths
@@ -30,7 +30,6 @@ import io.mockk.impl.annotations.MockK
 import org.koin.core.context.GlobalContext
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
-import org.koin.core.qualifier.named
 import org.koin.dsl.module
 import org.koin.test.KoinTest
 
@@ -80,9 +79,7 @@ class RoutingTest :
                         single { entriesCommentsService }
                         single { oauthGoogleRepository }
                         single { oauthGoogleService }
-                        single(named("pre-oauth-states")) {
-                            mutableMapOf<String, PreOauthState>()
-                        }
+                        single { OauthStateCodec(ByteArray(32)) }
                         single { OauthGoogle("", "", "", "") }
                         single { httpClient }
                     },


### PR DESCRIPTION
## 概要

Lambda移行プロジェクト フェーズ2: セッションとOAuth stateをステートレス化する。**本プロジェクトで最もリスクの高い工程。**

計画書: `docs/projects/lambda/migration-plan.md` のフェーズ2

## なぜ必要か

Lambdaは実行環境が複数並走・随時リサイクルされるため、プロセス内メモリに状態を持てない。障壁は4箇所あった:

| 箇所 | 内容 |
|---|---|
| `Sessions.kt` | `UserSession` / `ClientSession` / `CsrfTokenSession` の3つが `SessionStorageMemory` を使用 |
| `AuthenticationModule.kt` | `pre-oauth-states` が `mutableMapOf`。**OAuth開始とコールバックが別環境に着弾するとサインイン失敗**（最も確実に壊れる） |
| `AuthenticationModule.kt` | `StatelessHmacNonceManager` の鍵が `generateNonce()` によるプロセス毎のランダム値 |

## 変更内容（4コミット）

### 1. `SESSION_SIGN_KEY` の導入（fail-fast）

`SessionSignKey.kt`（新規）: hex文字列をパースし、**未設定 / 32hex文字未満 / hexとして不正なら例外で即死**させる。黙って安全でないデフォルト値にフォールバックしない。Koinの `single(createdAtStart = true)` で登録。

`application.conf` / `.ci.env` に配線、ローカル開発用のデフォルト値も用意。

### 2. 3種のセッションをステートレス化 + cookie属性の修正

`storage` 引数を外し、3つとも `transform(SessionTransportTransformerMessageAuthentication(signKey))` を付与。**header transport にも同じ transform が効くことを確認済み**（`HeaderSessionBuilder` も `transform()` を持つ）。

あわせて `cookie.secure` をProduction時 `true`、`cookie.httpOnly` を常に `true` に修正し、誤診だった既存TODOコメントを削除。

### 3. `expiresAt` を署名対象に含める

`UserSession` に `expiresAt: Long` を追加（署名対象に自動的に含まれる）。`AuthenticationUser` / `AuthenticationAdmin` の `validate` で明示的に期限チェック。

セッション生成5箇所（サインアップ、サインイン、OAuth 3箇所）を `newUserSession(id)` ヘルパーに一元化し、**絶対期限**（サインイン時に7日後を刻み以後更新しない）にした。スライディング期限は漏洩トークンを延命させるため採用していない。

### 4. OAuth state のステートレス化 + nonce鍵の固定化

`OauthStateCodec.kt`（新規）: `PreOauthState` をJSON化してBase64url + HMAC-SHA256で署名し、**OAuthの `state` パラメータそのものに埋め込む**。定数時間比較（`MessageDigest.isEqual`）と有効期限検証つき。

`OauthStateNonceManager` はこれをKtorの `NonceManager` 契約にアダプトする薄いラッパー。

## Ktor の `state` パラメータ上書きについて（レビュー最重点）

Ktorの `NonceManager.newNonce()` は引数を取らないため、呼び出しコンテキスト（redirectUrl、userId）を渡せない。そこで `authorizeUrlInterceptor` の中で `parameters.set("state", ...)` により署名済みトークンで上書きしている。

これは「interceptor が呼ばれる時点で `parameters` に `state` が既に入っている」ことに依存する。**この前提は変更前のコードが既に依拠していたもの**:

```kotlin
// 変更前
authorizeUrlInterceptor = interceptor@{
    val state = parameters["state"] ?: return@interceptor   // ← state が既にある前提
    val nonce = preOauthStates[state]?.nonce ?: return@interceptor
```

つまり本番でOAuthが機能していた事実がこの順序の裏付けになっている。実装時には `ktor-server-auth` のバイトコードも読んで `authorizeUrlInterceptor` が `state` 追加後に呼ばれることを確認している。あわせて `onStateCreated` の戻り値が実際には捨てられていることも確認したため、no-op にしてある。

## 検証

すべてdocker composeで実機確認した。

### アプリ再起動後もセッションが維持される（最重要）

サインアップでcookieを取得 → `docker restart` でコンテナ（＝JVMプロセス）を完全に再起動 → **再起動前のcookieのまま `GET /api/v1/users/current` が200** で正しいユーザーを返した。プロセス内メモリに何も残っていないのに認証が通るので、ステートレス化が証明できている。

### 期限切れトークンの拒否

同じ署名鍵で `expiresAt` を過去にしたcookieを手作りしHMAC-SHA256で正しく署名 → **401**（署名は正しいのに期限切れで弾かれる）。未来の `expiresAt` は200、署名改竄は401も確認。

### その他

- サインイン → リロード → サインアウト: 全て正常（サインアウト後401）
- CSRF必須のPOST/PATCH/DELETE: トークンありで200、なしで403（`CsrfHeaderRequired`）
- Production cookie属性: `DEVELOPMENT=false` で `Set-Cookie` に `Secure; HttpOnly; SameSite=Strict` が付くことを確認
- `./gradlew build -x karate:test` + `ktlintCheck`: **成功、テスト191件全パス**（レビュー時に独立して再実行し確認済み）

### cookieサイズ実測

計画書の見積もり（数十バイト）より大きかったが、4KB上限に対して余裕は十分。

| | サイズ |
|---|---|
| `user_session` | 約99バイト（percent-encode後119） |
| `client_session` | 約205バイト（同221） |
| Cookieヘッダ合計 | 約370バイト |
| `X-CSRF-Token` ヘッダ | 約400バイト |

## 検証できていないこと

- **Google OAuthの実サインイン**: 実クレデンシャルがないため未確認。ロジック（エンコード/デコード、署名、期限、改竄検知、NonceManagerアダプタ）は `OauthStateCodecTest.kt` で単体テスト済みだが、**Google側との実際のラウンドトリップは未検証**。計画書のフェーズ2成功条件どおり、**EC2実機での検証が必須**
- フロントエンド（Vercel）経由の実ブラウザ動作は未確認

## 計画書と異なる実装判断

1. **`StatelessHmacNonceManager` を別クラス（`OauthStateNonceManager`）に置き換えた**。計画書は「鍵を固定化」としか書いていなかったが、`state` の中身を独自フォーマットにした以上、元のnonceManagerの検証ロジックとは整合しないため
2. **OAuth state の有効期限は3分**にした。既存の `StatelessHmacNonceManager(timeoutMillis = 180_000)` に合わせた値（計画書に具体的な数値指定がなかったため既存挙動を踏襲）

## 既存挙動が変わる箇所

- **`cookie.secure = true`（Production）**: 計画書の分析どおりなら無害だが、万一ACM/API Gatewayの前提が違えばサインイン不能になる。**EC2実機検証が必須**
- **サインアウトの意味論**: 以前は「サーバー側ストレージから削除」＝即時失効だったが、今は「クライアントにcookie削除を指示するだけ」。**漏洩トークンは有効期限内は理論上再利用可能**（計画書に明記済みのステートレス方式共通のトレードオフ。緊急時は `SESSION_SIGN_KEY` のローテーションで全失効させる）
- **既存の全セッションが一度無効化される**: 旧cookieは署名を持たないため。ただし現状 `SessionStorageMemory` でデプロイごとに失われていたので退行ではない
- **アプリ再起動を跨いだOAuthフロー**: 以前は必ず失敗していた既存バグが、鍵固定化の副作用で**直った**（改善）

## マージ前の前提（完了済み）

- EC2の `.env` に `SESSION_SIGN_KEY` を設定（**設定済み**）
- `backend/infra/sensitive.tfvars` にも同じ値を設定（**設定済み**、フェーズ7でLambda環境変数に渡すため）

両者が同一の値でないと、フェーズ8の切り替え時点で全ユーザーがログアウトされる。

## レビュー観点

- **`state` パラメータ上書きの妥当性**（上記の依存関係）
- `expiresAt` の絶対期限方針と、`validate` での明示チェック位置
- `SessionSignKey` の fail-fast 条件（最小32hex文字）
- `OauthStateCodec` の署名・検証（定数時間比較、期限）
- Production で `cookie.secure = true` にする判断

## デプロイ後に必須の検証

**EC2にデプロイして実ブラウザで確認すること**（計画書のフェーズ2成功条件）:
- サインイン・サインアウト
- **Google OAuthサインイン**（ここが唯一ローカルで検証できていない）
- 記事投稿（CSRF）

## チェックリスト

- [x] ビルドとテストがパスする（191件全パス）
- [x] アプリ再起動後もセッションが維持される
- [x] 期限切れトークンが拒否される
- [x] CSRF が機能する
- [x] Production cookie属性が正しい
- [ ] レビュー完了
- [ ] **EC2実機でのGoogle OAuth検証**（マージ後）

Related: Lambda Migration Phase 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
