### PR TITLE
fix(ci): Lambdaが取得できるよう単一アーキのイメージをpushする

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -96,16 +96,39 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      # amd64は本番EC2 (t2.nano)、arm64はLambda (Graviton) 向け。
-      # 両方をpushしておくことで、EC2は現行通りamd64をpullし続けつつ、
-      # Lambda移行時にarm64をpullできる。
-      # Docker HubとECRの両方にpushする (移行期間中はEC2がDocker Hubから取得するため)。
-      - name: Build and push Docker image
+      # 消費者ごとにアーキテクチャが異なるため、単一プラットフォームのイメージを
+      # レジストリ別にpushする。1つのタグで両アーキを配るマルチアーキ (マニフェスト
+      # リスト) にはしない。理由は下のECR側のコメントを参照。
+      #
+      # Docker Hub: amd64 -> 本番EC2 (t2.nano, x86_64) が使う。
+      # フェーズ9でEC2を撤去したらこのステップごと不要になる。
+      - name: Build and push Docker image (amd64, Docker Hub)
         uses: docker/build-push-action@v7.3.0
         with:
           context: ./backend
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
+          provenance: false
           build-args: |
             JAVA_DOCKER_TAG=${{ steps.java-tag.outputs.java_docker_tag }}
-          tags: miyado/kottage:latest, miyado/kottage:${{ env.new_version }}, ${{ steps.ecr-login.outputs.registry }}/kottage:latest, ${{ steps.ecr-login.outputs.registry }}/kottage:${{ env.new_version }}
+          tags: miyado/kottage:latest, miyado/kottage:${{ env.new_version }}
+
+      # ECR: arm64 -> Lambda (Graviton) が使う。
+      #
+      # Lambdaはマニフェストリスト (イメージインデックス) を解決できず、単一アーキテクチャの
+      # イメージマニフェストを直接指す必要がある。インデックスを指すタグを image_uri に
+      # 渡すと CreateFunction が InvalidParameterValueException
+      # ("The image manifest, config or layer media type ... is not supported") で失敗する。
+      #
+      # provenance: false が必須。buildxはattestationを付けるとその紐付け先として
+      # インデックスを作るため、platformsを1つに絞ってもインデックスになってしまう。
+      - name: Build and push Docker image (arm64, ECR)
+        uses: docker/build-push-action@v7.3.0
+        with:
+          context: ./backend
+          push: true
+          platforms: linux/arm64
+          provenance: false
+          build-args: |
+            JAVA_DOCKER_TAG=${{ steps.java-tag.outputs.java_docker_tag }}
+          tags: ${{ steps.ecr-login.outputs.registry }}/kottage:latest, ${{ steps.ecr-login.outputs.registry }}/kottage:${{ env.new_version }}


### PR DESCRIPTION
## 概要

Lambdaが取得できる形でECRにイメージをpushするようCIを修正する。

## 問題

`terraform apply` でLambdaを作成しようとすると失敗した:

```text
InvalidParameterValueException: The image manifest, config or layer media type
for the source image 899765742643.dkr.ecr.us-east-2.amazonaws.com/kottage:v1-202607250659
is not supported.
```

**Lambdaはマニフェストリスト（イメージインデックス）を解決できない。** buildxのマルチアーキビルドが作るタグはインデックスを指すため拒否される。

```text
tag v1-202607250659 → index (application/vnd.oci.image.index.v1+json)
                       ├─ linux/amd64
                       ├─ linux/arm64          ← Lambdaが必要なのはこれ単体
                       ├─ unknown/unknown      ← buildxのprovenance attestation
                       └─ unknown/unknown
```

arm64マニフェストのダイジェストを直接指定したところLambdaの作成に成功したため、**OCIメディアタイプ自体は問題なく、インデックスが原因**であることを確認済み。

## 修正方針

そもそも**1つのタグが両アーキを指す必要はなかった**。消費者はアーキテクチャごとに分かれている:

| 送り先 | アーキ | 消費者 | 期間 |
|---|---|---|---|
| Docker Hub | `linux/amd64` | 本番EC2（t2.nano, x86_64） | フェーズ9で撤去するまで |
| ECR | `linux/arm64` | Lambda（Graviton） | 以降ずっと |

そこで**単一プラットフォームのイメージをレジストリ別にpushする**形に変更した。フェーズ9でEC2を撤去したらDocker Hub側のステップごと消せるので、最終的には1ビルドに戻る。

### `provenance: false` が必須

これは装飾ではなく必須。**buildxはattestationを付けるとその紐付け先としてインデックスを作る**ため、`platforms` を1つに絞ってもインデックスになってしまう。

同じ理由で、これまでのpushはECRに毎回3〜4個のuntaggedマニフェスト（個別アーキ + attestation）を残していた。#533 で追加したuntagged向けライフサイクルルールは、この修正後は残骸の掃除が主な役割になる。

## なぜマルチアーキにしていたか（経緯）

フェーズ4の時点では、移行計画の柱が「**アプリ変更を現行EC2で本番検証してから移行する**」であり、同じイメージがEC2でもLambdaでも動く必要があった。その目的は果たしており、実際にフェーズ2のステートレス化はEC2上でGoogle OAuthの実往復まで検証できている。

必要だったのは「両アーキが存在すること」であって「1つのタグが両方を指すこと」ではなかった、というのが今回の学び。

## なぜarm64を維持するか

無料枠に収まっているため、arm64の20%割引は現時点で$0の価値しかない。すべてamd64に統一する選択肢もあったが、**arm64でコールドスタート6.0秒という計測値が既に取れており**（#533の7.5節）、amd64に変えると判断ゲートをやり直すことになるため維持する。

## テスト

- [x] Ruby の YAML パーサで構文を検証。2つのbuild-pushステップが `platforms` / `provenance` とも意図通りに構成されていることを確認
- [x] arm64マニフェストのダイジェスト直指定でLambdaが起動し、`/api/v1/health` と `/api/v1/entries`（実データ180件）が200を返すことを確認済み

**マージ後、実際のpushで検証が必要**:

- ECRのタグが `application/vnd.oci.image.manifest.v1+json`（インデックスではない）を指すこと
- untaggedマニフェストが生成されなくなること
- Docker Hub側のamd64イメージでEC2が従来通り動くこと
- `app_image_tag` にダイジェストではなくタグを渡してLambdaが作成できること

確認コマンド:

```bash
aws ecr describe-images --region us-east-2 --repository-name kottage \
  --query 'sort_by(imageDetails,&imagePushedAt)[-3:].[imageTags[0],imageManifestMediaType]' --output text
```

## 関連

#533（フェーズ7）の `lambda_app.tf` は `app_image_tag` がタグとダイジェストの両方を受け付けるようにしてある。本PRのマージ後はタグを渡せば済むが、ダイジェスト指定は緊急時の手段として残しておいて損はない。

両PRにファイルの重複はないため、マージ順は問わない。

Related: Lambda Migration Phase 7

🤖 Generated with [Claude Code](https://claude.com/claude-code)
