### PR TITLE
[Lambda Migration] Phase 8: 本番トラフィックをLambdaへ切り替え

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -132,3 +132,42 @@ jobs:
           build-args: |
             JAVA_DOCKER_TAG=${{ steps.java-tag.outputs.java_docker_tag }}
           tags: ${{ steps.ecr-login.outputs.registry }}/kottage:latest, ${{ steps.ecr-login.outputs.registry }}/kottage:${{ env.new_version }}
+
+      # フェーズ8: Lambda移行 (docs/projects/lambda/migration-plan.md の8.1/8.2)。
+      # kottage_app (backend/infra/lambda_app.tf) は image_uri の変更を
+      # lifecycle.ignore_changes で無視しているため、以後のイメージ更新はここで行う。
+      #
+      # 上のECR pushは単一アーキ (arm64) かつ provenance 無効なので、タグは
+      # イメージインデックスではなく単一マニフェストを直接指す。Lambdaはインデックスを
+      # 解決できないが、この形ならタグをそのまま渡せる。
+
+      # kottage_appの$LATESTを新イメージへ更新する。この時点ではまだ"live"
+      # エイリアスは古いバージョンを指したままなので、本番トラフィックには影響しない。
+      - name: Update kottage_app Lambda function code
+        run: |
+          aws lambda update-function-code \
+            --function-name kottage_app \
+            --image-uri "${{ steps.ecr-login.outputs.registry }}/kottage:${{ env.new_version }}"
+
+      - name: Wait for the function update to complete
+        run: aws lambda wait function-updated --function-name kottage_app
+
+      # $LATESTの内容をイミュータブルなバージョンとして発行する。
+      - name: Publish a new kottage_app version
+        id: lambda-version
+        run: |
+          version=$(aws lambda publish-version \
+            --function-name kottage_app \
+            --description "delivery.yml ${{ env.new_version }}" \
+            --query 'Version' --output text)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      # API Gatewayが実際に呼び出すのは"live"エイリアスのみ。ここで初めて
+      # 本番トラフィックが新バージョンへ切り替わる。ロールバックは、このエイリアスを
+      # 前のバージョンに戻す `aws lambda update-alias` で即時に行える。
+      - name: Point the live alias at the new version
+        run: |
+          aws lambda update-alias \
+            --function-name kottage_app \
+            --name live \
+            --function-version "${{ steps.lambda-version.outputs.version }}"

--- a/backend/infra/api_gateway.tf
+++ b/backend/infra/api_gateway.tf
@@ -1,5 +1,5 @@
 resource "aws_apigatewayv2_api" "kottage" {
-  name = "kottage"
+  name          = "kottage"
   protocol_type = "HTTP"
 }
 
@@ -13,17 +13,26 @@ resource "aws_apigatewayv2_integration" "kottage" {
   api_id           = aws_apigatewayv2_api.kottage.id
   integration_type = "AWS_PROXY"
 
-  connection_type           = "INTERNET"
-  description               = "proxy to lambda http-proxy"
-  integration_method        = "POST"
-  integration_uri           = module.lambda_http_proxy.lambda_invoke_arn
+  connection_type    = "INTERNET"
+  description        = "proxy to app lambda (kottage_app:live)"
+  integration_method = "POST"
+  # フェーズ8: 本番切替。http_proxy（VPC内）からアプリLambdaのエイリアスへ変更。
+  # ロールバックは、この値を module.lambda_http_proxy.lambda_invoke_arn に戻すだけ
+  # （module.lambda_http_proxyとEC2は削除せず稼働させたまま残している。
+  # 詳しくはmigration-plan.mdフェーズ8「ロールバック手順」を参照）。
+  integration_uri        = aws_lambda_alias.kottage_app_live.invoke_arn
   payload_format_version = "2.0"
-  timeout_milliseconds = 10000
+  # 実測のコールドスタートは6.0秒（1769MB）。旧経路（http_proxy、関数timeout=10秒）に
+  # 合わせた10000msのままだと、コールドスタート直後にDB接続などの実処理が乗った場合に
+  # 統合タイムアウトが先に切れてしまう余地が大きい。アプリLambda自身のtimeout（29秒、
+  # lambda_app.tf）と一致させ、API Gateway側が先に打ち切ることがないようにする
+  # （HTTP APIの統合タイムアウト上限は30000ms）。
+  timeout_milliseconds = 29000
 }
 
 resource "aws_apigatewayv2_stage" "kottage_default" {
-  api_id = aws_apigatewayv2_api.kottage.id
-  name   = "$default"
+  api_id      = aws_apigatewayv2_api.kottage.id
+  name        = "$default"
   auto_deploy = true
 
   tags = {

--- a/backend/infra/github_oidc.tf
+++ b/backend/infra/github_oidc.tf
@@ -92,3 +92,45 @@ resource "aws_iam_role_policy" "github_actions_ecr_push" {
     ]
   })
 }
+
+# フェーズ8: イメージ更新の主体をTerraformからCIへ移すため（migration-plan.mdの8.1）、
+# delivery.ymlがECR pushの後に「アプリLambdaのコード更新 → バージョン発行 →
+# エイリアス切替」まで行う。そのための権限をこのロールに追加する。
+#
+# 【命名について】このロール/リソースアドレスは "github_actions_ecr_push" /
+# "ecr_push" だが、フェーズ8以降はECR pushだけでなくLambdaデプロイの権限も持つため
+# 実態と乖離している。ただしIAMロールのnameはForceNew（変更すると再作成になり、
+# 信頼ポリシーの再確立とGitHub Actions側のAWS_GITHUB_ACTIONS_ROLE_ARN変数の更新が
+# 必要になる）ため、本PRでは名前を変更せず、権限だけをこのロールに追加する形にした。
+# リネームする場合は、ロールバック中でない安定期に別PRとして計画すること。
+resource "aws_iam_role_policy" "github_actions_lambda_deploy" {
+  name = "lambda_deploy"
+  role = aws_iam_role.github_actions_ecr_push.id
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = [
+          # `aws lambda update-function-code` でイメージを差し替える。
+          "lambda:UpdateFunctionCode",
+          # `aws lambda wait function-updated` が使うポーリング先。waiterの実装
+          # バージョンにより GetFunctionConfiguration / GetFunction のどちらを
+          # 呼ぶか変わりうるため両方を許可する（読み取り専用で実害はない）。
+          "lambda:GetFunctionConfiguration",
+          "lambda:GetFunction",
+          # `aws lambda publish-version` で新バージョンを発行する。
+          "lambda:PublishVersion",
+          # `aws lambda update-alias` で "live" エイリアスの向き先を切り替える。
+          "lambda:UpdateAlias"
+        ],
+        # kottage_app関数のみに限定する（無出力・有出力ARNの両方をカバー）。
+        # 他のLambda関数（http_proxy等）には一切権限を与えない。
+        Resource = [
+          aws_lambda_function.kottage_app.arn,
+          "${aws_lambda_function.kottage_app.arn}:*"
+        ]
+      }
+    ]
+  })
+}

--- a/backend/infra/lambda_app.tf
+++ b/backend/infra/lambda_app.tf
@@ -71,13 +71,29 @@ resource "aws_lambda_function" "kottage_app" {
   role          = aws_iam_role.kottage_app.arn
 
   package_type = "Image"
-  # イメージタグは常に変数で指定する。"latest"に固定すると、今どのビルドがデプロイ
-  # されているかTerraformの差分から追えなくなるため。
+  # var.app_image_tagはフェーズ7時点の初期値としてのみ使う。フェーズ8以降は
+  # image_uriの実際の更新をCIに委ねるため（下記lifecycle.ignore_changesと
+  # migration-plan.mdの8.1を参照）、apply毎にこの変数を書き換える運用は終わる。
+  # "latest"は使えない。LambdaはUpdateFunctionCode時点でタグをダイジェストに
+  # 解決して固定するため、後から"latest"に新イメージをpushしても稼働中の関数は
+  # 変わらず、Terraformの差分にも表れない（詳細はmigration-plan.mdの8.1）。
   # Lambdaはマニフェストリスト（イメージインデックス）を解決できず、単一アーキテクチャの
   # マニフェストを直接指す必要がある。buildxのマルチアーキビルドが作るタグはインデックスを
   # 指すため、タグではなくarm64マニフェストのダイジェストを渡す。
   # "sha256:..." が渡されたら "@" で、通常のタグなら ":" で連結する。
   image_uri = "${aws_ecr_repository.kottage.repository_url}${startswith(var.app_image_tag, "sha256:") ? "@" : ":"}${var.app_image_tag}"
+
+  # フェーズ8: デプロイのたびにTerraformを触らずに済むよう、image_uriの以後の更新は
+  # CI（delivery.yml）の `aws lambda update-function-code` に委ねる。Terraformは
+  # 初期値を与えるだけにし、CIが更新した後の差分を無視する。
+  lifecycle {
+    ignore_changes = [image_uri]
+  }
+
+  # フェーズ8: バージョンを発行し、aws_lambda_alias経由でAPI Gatewayから
+  # 呼び出す（下記）。ロールバックは「エイリアスを前のバージョンに戻す」だけで
+  # 完結するようにするための変更。
+  publish = true
 
   # フェーズ4でarm64マルチアーキ対応済み。x86_64より約2割安い。
   architectures = ["arm64"]
@@ -139,4 +155,35 @@ resource "aws_lambda_function" "kottage_app" {
     Name    = "kottage_app"
     Service = "kottage"
   }
+}
+
+# フェーズ8: API Gatewayはこのエイリアスを呼び出す（本番切替はapi_gateway.tfの
+# aws_apigatewayv2_integration.kottageのintegration_uriを参照）。デプロイ後の
+# ロールバックは、このエイリアスのfunction_versionを前のバージョンに戻すだけで
+# 完結する（terraform applyを介さず `aws lambda update-alias` で即時に行える）。
+#
+# function_versionはCI（delivery.yml）の `aws lambda publish-version` /
+# `aws lambda update-alias` が継続的に更新する。Terraformが管理するのは
+# 初期値（最初にpublishされたバージョン）だけであり、以後はignore_changesで
+# 差分を無視する。ignore_changesが無いと、CIが切り替えたバージョンをTerraformが
+# 次のapplyで元の値に巻き戻してしまう。
+resource "aws_lambda_alias" "kottage_app_live" {
+  name             = "live"
+  function_name    = aws_lambda_function.kottage_app.function_name
+  function_version = aws_lambda_function.kottage_app.version
+
+  lifecycle {
+    ignore_changes = [function_version]
+  }
+}
+
+# 既存の aws_lambda_permission.api_gateway（lambda.tf）はhttp_proxy向けのため、
+# アプリLambdaのエイリアスを起動する権限は別途必要。qualifierでエイリアス経由の
+# 呼び出しのみを許可する。
+resource "aws_lambda_permission" "api_gateway_kottage_app" {
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_alias.kottage_app_live.function_name
+  qualifier     = aws_lambda_alias.kottage_app_live.name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.kottage.execution_arn}/*/*"
 }

--- a/backend/infra/lambda_app.tf
+++ b/backend/infra/lambda_app.tf
@@ -126,9 +126,19 @@ resource "aws_lambda_function" "kottage_app" {
       MYSQL_PASSWORD = var.mysql_password
       MYSQL_SSL_MODE = var.mysql_ssl_mode
 
-      # フェーズ3で起動時処理から分離済み。コールドスタート毎のFlyway実行と、
-      # 複数実行環境からの同時マイグレーションを避ける。
-      RUN_MIGRATION_ON_STARTUP = "false"
+      # 起動時にマイグレーションを実行する。フェーズ3で分離「できる」ようにはしたが、
+      # Lambdaで分離を実際に使う手段が無いため、ここでは起動時実行を選ぶ
+      # （経緯と他案との比較は migration-plan.md の 8.3）。
+      #
+      # 分離側の当初案は「マイグレーション用LambdaをOIDCでinvoke」だったが、Lambdaの
+      # 実行モデルはランタイムAPIに応答し続けるプロセスであり、実行して終了するCLIを
+      # そのままでは動かせない。falseのまま切り替えると、スキーマ変更が二度と適用され
+      # なくなる方が危険。
+      #
+      # コストは許容できる。実測のコールドスタートは6.0秒で、Flywayが履歴テーブルを
+      # 確認するだけの往復は相対的に小さい。同時コールドスタートもFlywayがロックを
+      # 取るため安全に直列化される。
+      RUN_MIGRATION_ON_STARTUP = "true"
 
       # 【重要】EC2の.envに設定されている値と完全に同一でなければならない。
       # 異なるとフェーズ8の切替時点で全ユーザーがログアウトされる。

--- a/docs/projects/lambda/README.md
+++ b/docs/projects/lambda/README.md
@@ -172,7 +172,7 @@ feature/phase{N}-lambda-{description}
 |---------|----------------|
 | `AuthenticationModule.kt` | 1, 2 |
 | `Dockerfile` | 4, 6 |
-| `delivery.yml` | 3, 5, 9 |
+| `delivery.yml` | 3, 5, 8, 9 |
 | `application.conf` | 1, 2 |
 
 ---

--- a/docs/projects/lambda/migration-plan.md
+++ b/docs/projects/lambda/migration-plan.md
@@ -766,12 +766,20 @@ Lambdaでは`DEVELOPMENT=false`を明示することでこれを是正する
 
 ### タスク
 
-- [ ] 本番 `aws_apigatewayv2_integration.kottage` の統合先を `http_proxy` からアプリLambdaへ変更
-- [ ] **イメージの更新をTerraformからCIへ移す**（下記8.1）
-- [ ] `terraform apply` 前に `terraform plan` の差分を確認し、変更が統合先のみであることを検証
-- [ ] 適用後、実ブラウザで全機能を確認
-- [ ] **EC2とhttp_proxy Lambdaは削除せず稼働させたまま残す**
-- [ ] CloudWatch Logsでエラーを監視
+- [x] 本番 `aws_apigatewayv2_integration.kottage` の統合先を `http_proxy` からアプリLambdaへ変更
+- [x] **バージョン発行とエイリアス（`live`）を導入する**（下記8.2）
+- [x] **イメージの更新をTerraformからCIへ移す**（下記8.1）
+- [ ] `terraform apply` 前に `terraform plan` の差分を確認し、変更が統合先のみであることを検証（人間が実施）
+- [ ] 適用後、実ブラウザで全機能を確認（人間が実施）
+- [x] **EC2とhttp_proxy Lambdaは削除せず稼働させたまま残す**
+- [ ] CloudWatch Logsでエラーを監視（適用後、継続的に実施）
+
+実装は `backend/infra/lambda_app.tf`（バージョン発行・エイリアス・API Gateway用の
+Lambda権限）、`backend/infra/api_gateway.tf`（統合先の切替）、
+`backend/infra/github_oidc.tf`（CI用IAM権限）、`.github/workflows/delivery.yml`
+（デプロイ後のLambdaコード更新・バージョン発行・エイリアス切替）を参照。
+**`terraform apply` は未実施**（人間が実施する）。マイグレーション実行方式は
+未解決のまま残っている（下記8.3）。
 
 ### 8.1 イメージ更新の主体をCIに移す
 
@@ -820,16 +828,202 @@ lifecycle {
 **窓をマイグレーション実行時間＋数秒に縮められる**。8.1と7.2は同じ仕組みの両面であり、
 まとめて実装する。
 
+**実装**: `backend/infra/lambda_app.tf` の `aws_lambda_function.kottage_app` に
+`lifecycle { ignore_changes = [image_uri] }` を追加した。CI側は
+`.github/workflows/delivery.yml` の `Update kottage_app Lambda function code` 以降の
+ステップで `update-function-code` → `wait function-updated` → `publish-version` →
+`update-alias` を実行する。対象のIAM権限は `backend/infra/github_oidc.tf` の
+`aws_iam_role_policy.github_actions_lambda_deploy`（`aws_iam_role.github_actions_ecr_push`
+に追加。kottage_app関数のARNのみに限定）。
+
+### 8.2 バージョン発行とエイリアス（ロールバックの高速化）
+
+`aws_lambda_function.kottage_app` は当初 `publish = false` で `$LATEST` のみを
+稼働させていた。`$LATEST` は常に最新のコード/イメージを指す可変のポインタであり、
+「1つ前の状態」を指す手段がない。ロールバックのたびに前のイメージへ
+`update-function-code` を打ち直す必要があり、この場合CI/CDの外（人間の手作業）で
+前のイメージのURIを調べて指定することになる。
+
+これを避けるため、以下を導入した:
+
+- `publish = true` にし、`update-function-code` のたびにイミュータブルな
+  バージョン（1, 2, 3, ...）を発行できるようにする
+- `aws_lambda_alias.kottage_app_live`（エイリアス名 `live`）を追加し、
+  API Gateway（`aws_apigatewayv2_integration.kottage`）はこのエイリアスの
+  `invoke_arn` を呼び出すようにする
+- エイリアスの起動権限として `aws_lambda_permission.api_gateway_kottage_app` を
+  追加した（既存の `aws_lambda_permission.api_gateway` は http_proxy 向けであり
+  別物。qualifierに `live` を指定し、エイリアス経由の呼び出しのみを許可する）
+
+この結果、ロールバックは「エイリアス `live` の `function_version` を前の番号に
+戻す」だけになり、次の1コマンド（数秒）で完結する。前のイメージがどのURIだったかを
+調べ直す必要がない。
+
+```sh
+aws lambda update-alias --function-name kottage_app --name live --function-version <前の番号>
+```
+
+**Terraformとの競合に注意**: エイリアスの `function_version` はCIが継続的に
+書き換える値であり、Terraformの定義値（`aws_lambda_function.kottage_app.version`）
+とは別物として扱う必要がある。`aws_lambda_alias.kottage_app_live` にも
+`lifecycle { ignore_changes = [function_version] }` を付けているのはこのため。
+これが無いと、CIが本番トラフィックを新バージョンへ切り替えた後に誰かが
+`terraform apply` を実行した際、エイリアスがTerraform側の古い値（最初にpublishされた
+バージョン）に巻き戻され、**意図せず本番が古いコードへロールバックしてしまう**。
+
+### 8.3 未解決の設計課題: マイグレーション実行方式
+
+**本フェーズのスコープ外。実装はしていない。** フェーズ8を実際に切り替える前に、
+人間が以下から方式を決定する必要がある。
+
+#### 問題
+
+`RUN_MIGRATION_ON_STARTUP=false`（フェーズ3・7で導入済み）のまま本番切替を行うと、
+Flywayマイグレーションを実行する経路がどこにも無くなる。7.2で「マイグレーション用
+LambdaをOIDCでinvokeする」という設計を示したが、**実現手段が詰まっている**。
+
+Lambdaの実行モデルは「ランタイムAPIに応答し続けるプロセス」を前提としており、
+`kottage migrate`（フェーズ3で追加したCLIサブコマンド）のように「実行して終了する」
+プロセスはそのままでは動かない。実際にフェーズ7の検証中、アプリの起動に失敗した際
+`Runtime exited with error: exit status 1` という形でこの制約を確認している
+（ハンドラを one-shot で終了するプロセスにすると、Lambdaランタイムが
+「ハンドラを呼ぶ前にプロセスが死んだ」と解釈してエラーになる）。
+
+#### 選択肢
+
+##### 案1: `RUN_MIGRATION_ON_STARTUP=true` に戻す
+
+フェーズ3以前の挙動に戻し、コールドスタート毎にFlywayを実行させる。
+
+- メリット: 最も単純。実装済みのコードパスをそのまま使える。実測でコールドスタートは
+  6.0秒であり、Flywayの実行(数百ms程度)が相対的に小さい。Flywayは
+  `flyway_schema_history` テーブルでロックを取るため、複数コールドスタートが
+  同時に発生してもマイグレーションが二重適用される心配はない
+- デメリット・確認事項: フェーズ3で「マイグレーションを起動時処理から分離する」と
+  決めた判断を部分的に覆す。コールドスタート毎に(何もマイグレーションが無くても)
+  Flywayのメタデータ確認クエリが走り、DBへの往復が増える。マイグレーション失敗時、
+  アプリ全体が起動不能になる(フェーズ3以前と同じリスクが復活する)
+
+##### 案2: マイグレーション専用Lambda(同一イメージ、`image_config.command`上書き)
+
+同じECRイメージを使い、Lambda関数定義側で `image_config.command` を
+`["migrate"]` 等に上書きして「migrateだけ実行するLambda」を別関数として作る。
+
+- メリット: イメージのビルド・pushは1本で済む(アプリ用イメージを流用)。
+  関数を分ければIAMロールもマイグレーション専用に絞れる
+- デメリット・確認事項: **Lambdaランタイムとの整合が未確認。**
+  `image_config.command` の上書きは、DockerイメージのENTRYPOINT/CMDで起動する
+  対象を変えるものであり、Lambdaランタイムインターフェース(RIC: Runtime
+  Interface Client、またはLambda Web Adapterのようなカスタムランタイム経由)が
+  期待する「ハンドラを繰り返し呼び出せるプロセス」という契約とは別次元の話である。
+  現在のイメージはLambda Web Adapterを使い、Ktorサーバーを `0.0.0.0:8080` で
+  起動し続けるプロセスをRIEが待ち受ける構成になっている。`command` を
+  `["migrate"]` に差し替えた場合、`kottage migrate` は処理が終わり次第
+  プロセスが終了するため、フェーズ7で確認した `Runtime exited with error` と
+  同じ状態になる可能性が高い。**LWAを経由しない別のENTRYPOINT(Lambda Custom
+  Runtime向けのbootstrapを介して1回だけハンドラを実行し正常終了する形)を
+  別途用意する必要があるかどうか、実機で検証していない**
+
+##### 案3: アプリに認証付き内部エンドポイントを追加(例: `/internal/migrate`)
+
+アプリLambda自身に、マイグレーションを実行するHTTPエンドポイントを追加し、
+CIがデプロイ後にそれを叩く。
+
+- メリット: 新しいLambda関数やIAMロールが不要。既存のアプリLambda・エイリアス
+  経由の呼び出しの仕組み(8.2)をそのまま使える
+- デメリット・確認事項: アプリのKotlinコードに変更が必要(本タスクのスコープ外、
+  別タスクが並行してOAuth関連ファイルを触っているため今回は着手していない)。
+  エンドポイントの認証方式の設計が要る(Basic認証の使い回しか、専用トークンか)。
+  実行中に他のリクエストを受け付け続けるプロセス内でFlywayを走らせることになり、
+  Flywayのロック待ちで通常のAPIリクエストのレイテンシに影響しないか確認が要る。
+  誤って公開されるとDBスキーマを書き換えられる攻撃面になるため、CORS・認証・
+  IP制限のいずれかで確実に塞ぐ必要がある
+
+##### 案4: その他(参考)
+
+例: GitHub Actionsのランナーから直接TiDBへ接続し、Flyway CLIをCI上で実行する
+(Lambdaを経由しない)。
+
+- メリット: Lambdaの実行モデルの制約を完全に回避できる。ローカルの
+  `./gradlew` 実行や既存のFlyway設定をほぼそのまま使える
+- デメリット・確認事項: TiDBへの到達性をCIランナー(GitHub Actions)から
+  インターネット経由で確保する必要がある。DB認証情報をCI側(GitHub Secrets)に
+  置くことになり、7.2で「Lambda経由にすることでGitHub SecretsにDB認証情報を
+  置かずに済む」としたメリットを失う。TiDB Serverless側でGitHub Actionsの
+  IPレンジからの接続を許可する設計が必要
+
+#### 特記事項
+
+- 案1は実装コストがゼロに近い（環境変数を1つ変えるだけ）が、フェーズ3の設計判断を
+  後退させる点を人間が許容できるかどうかが論点になる
+- 案2は「イメージ1本を使い回せる」という魅力があるが、**Lambdaランタイムインター
+  フェースとの整合が机上の検討に留まっており、実機検証が必須**。検証せずに採用すると
+  フェーズ7で発生した`Runtime exited with error`と同じ理由で本番マイグレーションが
+  機能しないリスクがある
+- 案3はアプリコード変更が必要なため、Kotlinコードに触るタイミング（OAuth関連の
+  並行作業が終わった後）を見計らう必要がある
+- どの案を採るにせよ、**フェーズ8の本番切替（`terraform apply` によるAPI Gateway統合先
+  変更）より前に決定し、動作確認を済ませておくこと**。切替後に初めてスキーマ変更が
+  必要になった時点で詰むと、切替を戻す（8.4のロールバック）以外に選択肢が無くなる
+
 ### 成功条件
 
 - [ ] `kottage.miyado.dev` 経由で全機能が動作する
 - [ ] フロントエンド（Vercel）からのCORSリクエストが成功する
 - [ ] エラー率がゼロである
 
-### ロールバック手順
+### 8.4 ロールバック手順
 
-統合先を `http_proxy` に戻して `terraform apply` するだけ。所要1〜2分。
-EC2は稼働し続けているため即座に復旧できる。
+エイリアス方式の導入により、ロールバック手段は**2段階**になった。事象に応じて
+使い分ける。
+
+#### 手段A: 統合先を `http_proxy` に戻す（経路そのものを疑う場合）
+
+API Gateway統合（`aws_apigatewayv2_integration.kottage`）が向くLambda自体を
+疑わしいと判断した場合（例: Lambda環境固有の障害、`vpc_config`なし構成に起因する
+接続問題、コールドスタートの許容範囲超過など）に使う。
+
+```text
+1. integration_uri を module.lambda_http_proxy.lambda_invoke_arn に戻す
+2. terraform plan で差分が integration_uri のみであることを確認する
+3. terraform apply
+```
+
+所要1〜2分。EC2とhttp_proxy Lambdaは稼働し続けているため即座に復旧できる。
+**アプリLambdaのバージョン・エイリアスの状態には触れない**ため、この手段だけでは
+アプリコード自体の不具合（EC2側にも同じイメージ・同じコードがデプロイされていれば
+EC2側でも再現する類の不具合）は解決しない。
+
+#### 手段B: エイリアスを前のバージョンに戻す（アプリコード自体を疑う場合）
+
+直近のデプロイ（CIによる `update-function-code` → `publish-version` →
+`update-alias`）で入れたコード自体に不具合があると判断した場合に使う。
+**`terraform apply` を介さない**ため、より高速。
+
+```sh
+# 現在のエイリアスが指しているバージョンを確認
+aws lambda get-alias --function-name kottage_app --name live
+
+# 1つ前の正常だったバージョンへ戻す
+aws lambda update-alias \
+  --function-name kottage_app \
+  --name live \
+  --function-version <直前の正常なバージョン番号>
+```
+
+所要は数秒〜1分。API Gatewayの統合先（アプリLambdaのエイリアス）自体は
+変更しないため、`terraform apply` が不要で最も速い。
+
+#### 使い分けの目安
+
+| 症状 | 手段 |
+|---|---|
+| 直近のデプロイ以降に発生した5xx・機能不全（アプリコード起因が疑わしい） | B（エイリアスを戻す） |
+| デプロイのタイミングと無関係に発生する障害、Lambda環境固有の問題（コールドスタート・非VPC構成起因の接続問題等） | A（http_proxyへ戻す） |
+| Bで解決しない、またはLambda自体（コールドスタート等）が原因と判明した | A（http_proxyへ戻す） |
+
+いずれの手段も**EC2とhttp_proxy Lambdaを削除しない**という本フェーズの前提があって
+初めて成立する（フェーズ9で撤去した後はAが使えなくなる）。
 
 ### 監視期間
 
@@ -891,7 +1085,7 @@ EC2は稼働し続けているため即座に復旧できる。
 | 2 | 同上。ただし署名鍵の扱いに注意（セッションは失効する） | 10分 |
 | 5 | 追加のみのため実質不要 | - |
 | 7 | 本番に影響しないため不要 | - |
-| 8 | API Gatewayの統合先を戻す | 1〜2分 |
+| 8 | 手段A: 統合先をhttp_proxyに戻す（1〜2分）／ 手段B: エイリアスを前バージョンへ戻す（数秒〜1分、`terraform apply`不要）。使い分けは8.4を参照 | 数秒〜2分 |
 | 9 | `terraform apply` でEC2を再作成し、統合先を戻す | 30分〜1時間 |
 
 ### 想定される問題と対応

--- a/docs/projects/lambda/migration-plan.md
+++ b/docs/projects/lambda/migration-plan.md
@@ -420,8 +420,9 @@ ENV AWS_LWA_ASYNC_INIT=true
 >   ことで確実に失敗し、検証にならない
 > - **フェーズ3への依存**: 7.5のコールドスタート計測は、起動時にFlyway
 >   マイグレーションが走らない（`RUN_MIGRATION_ON_STARTUP=false`）状態で行わないと
->   数値が汚染される。フェーズ3なしでは計測結果がマイグレーション込みの時間になり、
->   フェーズ8以降での実測と乖離する
+>   数値が汚染される。フェーズ3が導入したこのフラグが無ければ、計測値は
+>   マイグレーション込みの時間になり、Lambda自体の起動コストを切り分けられない。
+>   なお本番運用では8.3の判断により`true`に戻している
 >
 > フェーズ5・6への依存（ECRリポジトリ・Lambda Web Adapter組み込み済みのイメージが
 > 必要）は従来通り。
@@ -434,6 +435,8 @@ ENV AWS_LWA_ASYNC_INIT=true
 - [x] メモリは1024MBから開始し、計測結果で調整
 - [x] `timeout` は29秒以下（API Gateway HTTP APIの統合タイムアウト上限が30秒）
 - [x] 環境変数を設定: DB接続情報、`SESSION_SIGN_KEY`、OAuth関連、`VERCEL_DEPLOY_HOOK`、`RUN_MIGRATION_ON_STARTUP=false`、`DEVELOPMENT=false`
+      （`RUN_MIGRATION_ON_STARTUP`は7.5の計測を汚染しないためfalseにしていた。
+      フェーズ8で`true`に変更している。経緯は8.3）
 - [x] `aws_cloudwatch_log_group` を明示的に作成し保持期間を設定（14日程度）
 実装は `backend/infra/lambda_app.tf`（Lambda本体・ロググループ・IAMロール）。
 環境変数の完全な一覧は本フェーズの7.7節を参照。
@@ -683,7 +686,7 @@ TLSハンドシェイクが含まれる。この分が約540msあり、**両経�
 | `MYSQL_USER` | `""` | 同上。`mysql_user`から |
 | `MYSQL_PASSWORD` | `""` | 同上。`mysql_password`から |
 | `MYSQL_SSL_MODE` | `DISABLED` | 同上。`mysql_ssl_mode`（Terraform側のデフォルトは`REQUIRED`） |
-| `RUN_MIGRATION_ON_STARTUP` | `true` | `false`を明示（フェーズ3で分離済み。コールドスタート毎のFlyway実行を避ける） |
+| `RUN_MIGRATION_ON_STARTUP` | `true` | フェーズ7の計測時は`false`（数値を汚染しないため）。フェーズ8で`true`に変更（8.3） |
 | `SESSION_SIGN_KEY` | `""` | `sensitive.tfvars`の`session_sign_key`から。**EC2の`.env`と同一の値でなければ切替時に全ユーザーがログアウトされる** |
 | `ADMIN_NAME` | `admin` | `sensitive.tfvars`の`admin_name`から |
 | `ADMIN_PASSWORD` | `admin` | `sensitive.tfvars`の`admin_password`から。デフォルトのままだと危険 |
@@ -871,10 +874,13 @@ aws lambda update-alias --function-name kottage_app --name live --function-versi
 `terraform apply` を実行した際、エイリアスがTerraform側の古い値（最初にpublishされた
 バージョン）に巻き戻され、**意図せず本番が古いコードへロールバックしてしまう**。
 
-### 8.3 未解決の設計課題: マイグレーション実行方式
+### 8.3 マイグレーション実行方式
 
-**本フェーズのスコープ外。実装はしていない。** フェーズ8を実際に切り替える前に、
-人間が以下から方式を決定する必要がある。
+**決定: 案1（`RUN_MIGRATION_ON_STARTUP=true`）を採る。** `lambda_app.tf` に反映済み。
+
+分離「できる」ようにしたフェーズ3の成果は残る。環境ごとに選べる状態は保たれており、
+将来コールドスタートを詰める必要が出たときや、案3のエンドポイント方式が整備された
+ときに切り替えられる。以下は判断の根拠として選択肢の比較を残したもの。
 
 #### 問題
 
@@ -891,7 +897,7 @@ Lambdaの実行モデルは「ランタイムAPIに応答し続けるプロセ�
 
 #### 選択肢
 
-##### 案1: `RUN_MIGRATION_ON_STARTUP=true` に戻す
+##### 案1: `RUN_MIGRATION_ON_STARTUP=true` に戻す（**採用**）
 
 フェーズ3以前の挙動に戻し、コールドスタート毎にFlywayを実行させる。
 


### PR DESCRIPTION
## 概要

Lambda移行プロジェクト フェーズ8: 本番トラフィックをEC2からアプリLambdaへ切り替える。

**`terraform apply` は未実行。** 実際の切り替えはレビュー後に人間が行う。

⚠️ **マージ前に決めるべき未解決課題が1つある**（下記「マイグレーション実行方式」）。

計画書: `docs/projects/lambda/migration-plan.md` のフェーズ8

## 変更内容

### 1. バージョン発行とエイリアス（`lambda_app.tf`）

- `publish = true` にしてバージョンを発行
- `aws_lambda_alias.kottage_app_live`（`live`）を追加し、API Gatewayはこのエイリアスを呼ぶ
- API Gateway用の `aws_lambda_permission` を `qualifier = "live"` で追加

エイリアスを挟むことで、**ロールバックが「エイリアスを前のバージョンに戻す」だけ**で済むようになる。

### 2. イメージ更新の主体をCIへ（計画書8.1）

Terraformは関数を定義するだけにし、以後のイメージ更新はCIに委ねる。

```hcl
lifecycle {
  ignore_changes = [image_uri]
}
```

`aws_lambda_alias` 側にも `ignore_changes = [function_version]` を付けている。**これが無いと、CIがエイリアスを新バージョンへ切り替えた後の `terraform apply` で古いバージョンへ巻き戻る。**

`delivery.yml` にECR push後の手順を追加:

```text
update-function-code → wait function-updated → publish-version → update-alias
```

**`live` エイリアスは最後の1ステップまで動かない。** 途中で失敗すれば本番は前バージョンのまま。

### 3. 本番API Gatewayの統合先切り替え（`api_gateway.tf`）

`integration_uri` を `module.lambda_http_proxy.lambda_invoke_arn` から `aws_lambda_alias.kottage_app_live.invoke_arn` へ変更。

**`module.lambda_http_proxy` とEC2は削除しない。** ロールバック先として残す（撤去はフェーズ9）。

#### `timeout_milliseconds` を 10000 → 29000 に変更

旧値の10000msは `http_proxy`（関数timeout=10秒）に合わせたもので、アプリLambda自身のtimeout（29秒）と整合していなかった。**実測コールドスタート6.0秒だけで6割を消費する**設計不整合。このリポジトリの既存パターン（統合タイムアウト = 関数timeout）に倣って29秒に揃えた。

### 4. IAM権限の追加（`github_oidc.tf`）

既存の `aws_iam_role.github_actions_ecr_push` に、Lambdaデプロイ用のポリシーを追加。

```text
Action:   UpdateFunctionCode / GetFunctionConfiguration / GetFunction
          / PublishVersion / UpdateAlias
Resource: kottage_app のARN と <ARN>:*（バージョン/エイリアス修飾子）のみ
```

`http_proxy` など他のLambdaには一切権限を与えていない。ロール名がECR専用を示唆するが、**名前変更はリソース再作成になる**ため見送った。

## レビュー時に修正した点

エージェントの実装は #534 のマージ前のブランチから分岐していたため、`delivery.yml` に**そのままでは必ず失敗するステップ**が含まれていた。

```yaml
# 削除したステップ
- name: Resolve arm64 image digest for Lambda
  run: |
    digest=$(docker buildx imagetools inspect ... --raw \
      | jq -r '.manifests[] | select(.platform.architecture == "arm64") | .digest')
```

このステップは**タグがイメージインデックスを指す前提**だった。#534 で単一アーキ + `provenance: false` のpushに変えたため、タグは単一マニフェストを直接指すようになっており、`.manifests[]` は存在しない。digestが空になってstep自体がエラー終了する。

ECRの実物で確認済み:

| タグ | メディアタイプ |
|---|---|
| `v1-202607250900`（#534前） | `application/vnd.oci.image.index.v1+json` |
| `v1-202607250904`（#534後） | **`application/vnd.oci.image.manifest.v1+json`** |

ダイジェスト解決は不要になったので、ステップごと削除して `--image-uri` にタグを直接渡す形にした。

## マイグレーション実行方式: 案1を採用（決定済み）

`RUN_MIGRATION_ON_STARTUP=false` のまま切り替えると、**Flywayマイグレーションを実行する経路がどこにも無くなり、スキーマ変更が二度と適用されなくなる**。

計画書7.2の「マイグレーション用LambdaをOIDCでinvoke」は実現手段が詰まっていなかった。Lambdaの実行モデルは「ランタイムAPIに応答し続けるプロセス」を前提としており、`kottage migrate` のように実行して終了するCLIはそのままでは動かない（フェーズ7で `Runtime exited with error: exit status 1` として実際に確認した形と同じ）。

**`RUN_MIGRATION_ON_STARTUP=true` に変更した。**

実測値に照らしてコストは小さい:

- コールドスタートは6.0秒。Flywayが履歴テーブルを確認する往復は相対的に軽い
- 同時コールドスタートはFlywayのロックで安全に直列化される

**フェーズ3の成果は失われない。** 分離「できる」能力はフラグとして残り、環境ごとに選べる状態は保たれる。将来コールドスタートを詰める必要が出たときや、8.3の案3（内部エンドポイント）が整備されたときに変数1つで切り替えられる。

選択肢の比較は計画書8.3に残してある。

## テスト

- [x] `terraform fmt -check` / `terraform validate` → Success
- [x] `delivery.yml` のYAMLパースと17ステップの構成を確認
- [x] IAMのResourceが `kottage_app` のみに限定されていることを確認
- [x] `main` にrebase済み（#534との競合を解消）

## apply前に人間が確認すべきこと

1. `terraform plan` の差分確認。初回applyでバージョン1が発行され、エイリアスがそれを指す
2. **適用順序**: 初回applyより前にCIが動くと `update-function-code` が対象不在で失敗する
3. 切り替え後、実ブラウザで全機能（サインイン・OAuth・記事投稿）を確認

## ロールバック手順（計画書8.4）

| 手段 | 内容 | 用途 |
|---|---|---|
| **B: エイリアス切り戻し** | `aws lambda update-alias` で前バージョンへ | 新イメージに問題がある場合。数秒 |
| **A: 統合先を戻す** | `integration_uri` を `module.lambda_http_proxy.lambda_invoke_arn` に戻して apply | Lambda経路自体に問題がある場合。1〜2分。EC2は稼働継続しているため即復旧できる |

Related: Lambda Migration Phase 8

🤖 Generated with [Claude Code](https://claude.com/claude-code)
