### PR TITLE
fix(logging): root に appender が付かずアプリのログが出ない問題を修正

### DIFF
--- a/backend/gradle/libs.versions.toml
+++ b/backend/gradle/libs.versions.toml
@@ -11,7 +11,6 @@ kotlin = "2.4.0"
 
 [libraries]
 logback = { module = "ch.qos.logback:logback-classic", version = "1.5.38" }
-janio = { module = "org.codehaus.janino:janino", version = "3.1.12" }
 javaJwt = { module = "com.auth0:java-jwt", version = "4.5.2" }
 jwksRsaJava = { module = "com.auth0:jwks-rsa", version = "0.24.1" }
 ktorServerNetty = { module = "io.ktor:ktor-server-netty", version.ref = "ktor" }
@@ -53,7 +52,7 @@ testKarate = { module = "com.intuit.karate:karate-junit5", version = "1.4.1" }
 buildSrc = ["kotlinpoet"]
 kottage = [
     # logback
-    "logback", "janio",
+    "logback",
     # ktor
     "ktorServerNetty", "ktorTest", "ktorAuth", "ktorAutoHeadResponse", "ktorCallLogging",
     "ktorContentNegotiation", "ktorCors", "ktorDefaultHeaders", "ktorStatusPages", "ktorSerializationJson",

--- a/backend/src/main/resources/logback.xml
+++ b/backend/src/main/resources/logback.xml
@@ -1,32 +1,35 @@
 <configuration>
-    <property scope="context" name="development" value="${DEVELOPMENT}"/>
+    <!--
+      以前は <if condition='...'> で DEVELOPMENT による分岐をしていたが、外側で宣言した
+      appender を分岐の中から appender-ref すると logback が参照を解決できず、
+      「Appender named [DEVELOPMENT] not referenced. Skipping further processing.」として
+      両方の appender を破棄していた。結果 root に appender が付かず、
+      logger.info / logger.error の出力が一切出ない状態だった。
+      <if> の condition 属性自体も deprecated なので、条件分岐をやめて環境変数で
+      ログレベルを与える形にする（janino への依存もこれで不要になる）。
 
-    <appender name="DEVELOPMENT" class="ch.qos.logback.core.ConsoleAppender">
+      LOG_LEVEL を DEVELOPMENT と分けているのは意図的。DEVELOPMENT は cookie の Secure 属性や
+      CORS の許可ホストも切り替えるため、本番で一時的にログを詳しくしたいだけの場面で
+      DEVELOPMENT=true にすると、セキュリティ設定まで緩んでしまう。
+
+      出力先は標準出力のみ。Lambda では標準出力がそのまま CloudWatch Logs に流れ、
+      EC2 では docker logs で読める。
+    -->
+    <variable name="LOG_LEVEL" value="${LOG_LEVEL:-INFO}"/>
+    <variable name="EXPOSED_LOG_LEVEL" value="${EXPOSED_LOG_LEVEL:-WARN}"/>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{YYYY-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36}@%file - %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
-    <appender name="PRODUCTION" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%d{YYYY-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
-        </encoder>
-    </appender>
-    <if condition='!property("development").equals("false")'>
-        <then>
-            <logger name="Exposed" level="debug"/>
-            <logger name="Application" level="trace"/>
-            <logger name="io.netty" level="info"/>
-            <root level="trace">
-                <appender-ref ref="DEVELOPMENT"/>
-            </root>
-        </then>
-        <else>
-            <logger name="Exposed" level="warn"/>
-            <logger name="Application" level="warn"/>
-            <logger name="io.netty" level="warn"/>
-            <root level="warn">
-                <appender-ref ref="PRODUCTION"/>
-            </root>
-        </else>
-    </if>
+
+    <!-- クエリログは既定では出さない。必要なときだけ EXPOSED_LOG_LEVEL=DEBUG で有効化する。 -->
+    <logger name="Exposed" level="${EXPOSED_LOG_LEVEL}"/>
+    <!-- Netty は INFO でも起動時に大量に出るため固定で絞る。 -->
+    <logger name="io.netty" level="WARN"/>
+
+    <root level="${LOG_LEVEL}">
+        <appender-ref ref="STDOUT"/>
+    </root>
 </configuration>


### PR DESCRIPTION
## 概要

**アプリケーションログが一度も出力されていなかった**既存バグを修正する。

## 問題

`logback.xml` は appender を `<if>` の**外側**で宣言し、`<then>` / `<else>` の**内側**から `appender-ref` していた。logback はこの境界を越えた参照を解決できず、起動時に以下を出して**両方の appender を破棄していた**。

```text
WARN AppenderModelHandler - Appender named [DEVELOPMENT] not referenced. Skipping further processing.
WARN AppenderModelHandler - Appender named [PRODUCTION] not referenced. Skipping further processing.
```

結果、root ロガーに appender が付かず、`logger.info` / `logger.error` の出力が一切コンソールに出ない。

**気づきにくい形の障害だった**: 警告は起動時のログに紛れて流れていくうえ、JVM のデフォルトハンドラは未捕捉例外を stderr に出し続けるため、「ログは出ている」ように見えてしまう。実際、フェーズ7 の DB 認証エラーを特定できたのは、たまたま `Exception in thread "main"` が stderr に出たからであって、アプリのログは何も出ていなかった。

## なぜ今直すか

EC2 なら `docker exec` でも `docker logs` でも中を調べられた。**Lambda では CloudWatch Logs が唯一の観測手段**で、しかもフェーズ8（#535）で本番トラフィックを Lambda へ切り替える。**最も観測が必要な瞬間にアプリのログが無い**状態は避けたい。

## 修正内容

条件分岐を**修復せずに削除した**。理由:

- `condition` 属性自体が deprecated（logback が起動時に警告を出している）
- 今回サイレントに壊れた原因がその仕組みそのもの
- `janino` への依存がこの構文のためだけに存在していた（コードからの参照はゼロ）→ **依存も削除した**

ログレベルは `LOG_LEVEL` 環境変数から取る形にした。

### `DEVELOPMENT` と分離した理由

`DEVELOPMENT` は cookie の `Secure` 属性と CORS の許可ホストも切り替える。旧構成では**本番でログを詳しくしたいだけの場面でも `DEVELOPMENT=true` にするしかなく、その瞬間にセキュリティ設定まで緩む**という結合があった。実際、今日 `DEVELOPMENT` 未設定のせいで本番の CORS が `localhost:3000` のみ許可になっていた問題が見つかっている。

### デフォルトを INFO にした

旧構成の本番相当は `WARN` だったが `INFO` にした。これにより CallLogging のリクエストログが出る。切り替え期間に有用で、このトラフィック量なら CloudWatch のコストは無視できる。抑えたい場合は `LOG_LEVEL=WARN` を設定すればよい。

`Exposed`（クエリログ）は既定 `WARN` のまま。必要なときだけ `EXPOSED_LOG_LEVEL=DEBUG` で有効化できる。

## 検証

ローカルコンテナで実機確認した。

### `DEVELOPMENT=false`（本番と同じ設定）でログが出ることを確認

```text
2026-07-25 09:28:54.128 [main] INFO  Application - Application started in 30.301 seconds.
2026-07-25 09:28:54.205 [DefaultDispatcher-worker-4] INFO  Application - Responding at http://0.0.0.0:8080
2026-07-25 09:28:55.755 [eventLoopGroupProxy-4-1] INFO  Application - 200 OK: GET - /api/v1/health in 24ms
2026-07-25 09:28:55.800 [eventLoopGroupProxy-4-2] INFO  Application - 200 OK: GET - /api/v1/entries in 27ms
2026-07-25 09:28:45.505 [main] ERROR Application - cannot connect to mysql after 7 times trial
```

**リクエストログもエラーログも、これまで一切見えていなかったもの。**

- [x] `Appender named [...] not referenced` の警告が **0件**
- [x] `LOG_LEVEL=WARN` を設定すると INFO 行が **0件**に抑制される
- [x] `./gradlew build ktlintCheck` → **BUILD SUCCESSFUL**（karate e2e 12件を含む）

## レビュー観点

- 条件分岐を削除して環境変数方式にした判断
- `LOG_LEVEL` を `DEVELOPMENT` から分離した判断
- デフォルトを `WARN` から `INFO` に変えた影響（CloudWatch のログ量）
- `janino` の削除

## 関連

#535（フェーズ8: 本番切り替え）の apply より前にマージ・デプロイしたい。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
