### PR TITLE
fix(hook): Vercelデプロイフックがレスポンス送出後に凍結する問題を修正

### DIFF
--- a/backend/src/main/kotlin/com/github/hmiyado/kottage/application/plugins/hook/Hook.kt
+++ b/backend/src/main/kotlin/com/github/hmiyado/kottage/application/plugins/hook/Hook.kt
@@ -3,44 +3,38 @@ package com.github.hmiyado.kottage.application.plugins.hook
 import com.github.hmiyado.kottage.route.matchesConcretePath
 import io.ktor.http.HttpMethod
 import io.ktor.server.application.ApplicationCall
-import io.ktor.server.application.ApplicationCallPipeline
-import io.ktor.util.pipeline.PipelinePhase
 
 data class Hook(
     val filter: HookFilter,
     val runner: suspend ApplicationCall.() -> Unit,
 )
 
-abstract class HookFilter(
-    val pipelinePhase: PipelinePhase,
-    /**
-     * if [insertAfter] is true, this hook is inserted after [pipelinePhase].
-     * if [insertAfter] is false, this hook is inserted before [pipelinePhase]
-     */
-    val insertAfter: Boolean = true,
-) : (HttpMethod, String) -> Boolean {
+/**
+ * どのリクエストにフックを反応させるかを決める述語。
+ *
+ * 実行位置は [RequestHook] が送信パイプラインの入口に固定しているため、
+ * ここでパイプラインフェーズを選ぶことはできない。以前は `pipelinePhase` と
+ * `insertAfter` を持っていたが、どちらも既定値のままでしか使われておらず、
+ * かつ既定の「`Call` フェーズの直後」がLambdaでフックを取りこぼす原因だった。
+ */
+abstract class HookFilter : (HttpMethod, String) -> Boolean {
     companion object {
         fun exactMatch(
             method: HttpMethod,
             path: String,
-            pipelinePhase: PipelinePhase = ApplicationCallPipeline.Call,
-            insertAfter: Boolean = true,
-        ) = object : HookFilter(pipelinePhase, insertAfter) {
+        ) = object : HookFilter() {
             override fun invoke(
                 p1: HttpMethod,
                 p2: String,
             ): Boolean = p1 == method && path.matchesConcretePath(p2)
         }
 
-        fun match(
-            pipelinePhase: PipelinePhase = ApplicationCallPipeline.Call,
-            insertAfter: Boolean = true,
-            block: (HttpMethod, String) -> Boolean = { _, _ -> false },
-        ) = object : HookFilter(pipelinePhase, insertAfter) {
-            override fun invoke(
-                p1: HttpMethod,
-                p2: String,
-            ): Boolean = block(p1, p2)
-        }
+        fun match(block: (HttpMethod, String) -> Boolean = { _, _ -> false }) =
+            object : HookFilter() {
+                override fun invoke(
+                    p1: HttpMethod,
+                    p2: String,
+                ): Boolean = block(p1, p2)
+            }
     }
 }

--- a/backend/src/main/kotlin/com/github/hmiyado/kottage/application/plugins/hook/RequestHook.kt
+++ b/backend/src/main/kotlin/com/github/hmiyado/kottage/application/plugins/hook/RequestHook.kt
@@ -1,16 +1,32 @@
 package com.github.hmiyado.kottage.application.plugins.hook
 
 import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.isSuccess
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.application.ApplicationCallPipeline
 import io.ktor.server.application.BaseApplicationPlugin
 import io.ktor.server.application.call
 import io.ktor.server.request.httpMethod
 import io.ktor.server.request.path
+import io.ktor.server.response.ApplicationSendPipeline
 import io.ktor.util.AttributeKey
-import io.ktor.util.pipeline.PipelinePhase
 import org.slf4j.Logger
 
+/**
+ * 特定のリクエストに反応して外向きのHTTPリクエストを送るプラグイン。
+ *
+ * フックは [ApplicationSendPipeline.Before]、つまり `call.respond()` が呼ばれた後・
+ * レスポンスが実際に送出される前に実行し、**完了を待ってからレスポンスを返す**。
+ *
+ * 以前は呼び出しパイプラインの `Call` フェーズの直後で実行していたが、その位置では
+ * レスポンスの送出が先に完了してしまう。EC2ではプロセスが動き続けるため遅れて送信されて
+ * いたが、Lambdaではレスポンスを返した時点でinvocationが終了し実行環境がfreezeされるため、
+ * 送信が飛びきる前に凍結してVercelのデプロイフックが発火しなかった。
+ *
+ * `Call` フェーズの「前」ではハンドラがまだ動いていない（記事が作られていない）ので、
+ * 「作成済み」かつ「レスポンス未送出」を満たすのは送信パイプラインの入口だけになる。
+ */
 class RequestHook(
     configuration: Configuration,
 ) {
@@ -18,37 +34,50 @@ class RequestHook(
     private val hooks: List<Hook> = configuration.hooks.toList()
 
     fun intercept(pipeline: ApplicationCallPipeline) {
-        hooks
-            .groupBy { hook -> hook.filter.pipelinePhase to hook.filter.insertAfter }
-            .forEach { (group, hooksByPhase) ->
-                val (phase, insertAfter) = group
+        if (hooks.isEmpty()) return
 
-                val hookPhase: PipelinePhase =
-                    if (insertAfter) {
-                        PipelinePhase("RequestHookAfter${phase.name}").also {
-                            pipeline.insertPhaseAfter(phase, it)
-                        }
-                    } else {
-                        PipelinePhase("RequestHookBefore${phase.name}").also {
-                            pipeline.insertPhaseBefore(phase, it)
-                        }
-                    }
-                pipeline.intercept(hookPhase) {
-                    val call = call
-                    val method = call.request.httpMethod
-                    val path = call.request.path()
-                    hooksByPhase
-                        .filter { hook -> hook.filter(method, path) }
-                        .forEach { hook ->
-                            try {
-                                hook.runner(call)
-                            } catch (e: Throwable) {
-                                logger?.error(e.message)
-                            }
-                        }
+        pipeline.sendPipeline.intercept(ApplicationSendPipeline.Before) { message ->
+            val method = call.request.httpMethod
+            val path = call.request.path()
+            val matched = hooks.filter { hook -> hook.filter(method, path) }
+            if (matched.isEmpty()) {
+                return@intercept
+            }
+
+            // 失敗したリクエストでは発火させない。以前はステータスを見ていなかったため、
+            // 例えばCSRFトークン無しの POST /entries が403で弾かれたときにも
+            // デプロイフックを叩いてしまい、記事が作られていないのにビルドが走っていた。
+            //
+            // 判定は「成功なら送る」ではなく「失敗と分かっているときだけ止める」にしている。
+            // `call.respond("ok")` のようにステータスを明示せず本文だけを返した場合、
+            // 送信パイプラインのどのフェーズでも status() は null のままで、200はエンジンが
+            // 最後に補う。「成功と確認できたときだけ送る」にすると、この経路のフックが
+            // 黙って落ちる。落とすなら理由が判明しているときだけにする。
+            val status = call.response.status() ?: statusOf(message)
+            if (status != null && !status.isSuccess()) {
+                logger?.debug(
+                    "skip {} hook(s) for {} {}: response status is {}",
+                    matched.size,
+                    method.value,
+                    path,
+                    status.value,
+                )
+                return@intercept
+            }
+
+            for (hook in matched) {
+                try {
+                    hook.runner(call)
+                } catch (e: Throwable) {
+                    // e.message は null になりうるので、それだけを渡すと空行が出るだけで
+                    // 何が起きたのか分からなくなる。例外そのものを渡してスタックトレースを残す。
+                    logger?.error("request hook failed for ${method.value} $path", e)
                 }
             }
+        }
     }
+
+    private fun statusOf(message: Any): HttpStatusCode? = message as? HttpStatusCode
 
     class Configuration {
         var logger: Logger? = null
@@ -73,8 +102,6 @@ class RequestHook(
     companion object Feature : BaseApplicationPlugin<ApplicationCallPipeline, Configuration, RequestHook> {
         override val key: AttributeKey<RequestHook>
             get() = AttributeKey("RequestHook")
-
-        private val phaseOnCallSuccess = PipelinePhase("OnCallSuccess")
 
         override fun install(
             pipeline: ApplicationCallPipeline,

--- a/backend/src/test/kotlin/com/github/hmiyado/kottage/application/plugins/hook/RequestHookTest.kt
+++ b/backend/src/test/kotlin/com/github/hmiyado/kottage/application/plugins/hook/RequestHookTest.kt
@@ -4,10 +4,13 @@ import io.kotest.assertions.throwables.shouldNotThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.core.test.TestCase
 import io.kotest.engine.test.TestResult
+import io.kotest.matchers.longs.shouldBeGreaterThanOrEqual
 import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.install
+import io.ktor.server.response.respond
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.routing
@@ -20,13 +23,24 @@ import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.just
 import io.mockk.verify
+import kotlinx.coroutines.delay
+import kotlin.time.TimeSource
 
 class RequestHookTest : DescribeSpec() {
+    private companion object {
+        const val SLOW_HOOK_DELAY = 300L
+    }
+
     private fun ApplicationTestBuilder.init() {
         with(application) {
             routing {
-                get("/") {}
-                post("/test") {}
+                // ステータスを明示する経路と、本文だけを返してエンジンに200を補わせる
+                // 経路の両方でフックが動くことを確かめる（後者は送信パイプラインの
+                // どのフェーズでも status() が null のままになる）。
+                get("/") { call.respond(HttpStatusCode.OK) }
+                post("/test") { call.respond("ok") }
+                post("/forbidden") { call.respond(HttpStatusCode.Forbidden) }
+                post("/slow-hook") { call.respond(HttpStatusCode.Created) }
             }
             install(RequestHook) {
                 hook(HttpMethod.Get, "/") {
@@ -38,6 +52,13 @@ class RequestHookTest : DescribeSpec() {
                 hook(HttpMethod.Get, "/exception") {
                     throw Exception()
                 }
+                hook(HttpMethod.Post, "/forbidden") {
+                    hookOnFailure()
+                }
+                hook(HttpMethod.Post, "/slow-hook") {
+                    delay(SLOW_HOOK_DELAY)
+                    hookSlow()
+                }
             }
         }
     }
@@ -47,6 +68,12 @@ class RequestHookTest : DescribeSpec() {
 
     @MockK
     lateinit var hook2: () -> Unit
+
+    @MockK
+    lateinit var hookOnFailure: () -> Unit
+
+    @MockK
+    lateinit var hookSlow: () -> Unit
 
     override suspend fun beforeTest(testCase: TestCase) {
         super.beforeTest(testCase)
@@ -80,6 +107,29 @@ class RequestHookTest : DescribeSpec() {
                     client.post("/test")
                     verify { hook1() }
                     verify { hook2() }
+                }
+            }
+            it("should not run hook when the response is not successful") {
+                testApplication {
+                    init()
+                    client.post("/forbidden")
+                    // 以前はステータスを見ずに発火していたため、CSRFで弾かれた403のような
+                    // 「実際には何も作られていない」リクエストでもフックが走っていた。
+                    verify(exactly = 0) { hookOnFailure() }
+                }
+            }
+            it("should finish the hook before sending the response") {
+                testApplication {
+                    init()
+                    every { hookSlow() } just Runs
+                    val start = TimeSource.Monotonic.markNow()
+                    client.post("/slow-hook")
+                    val elapsed = start.elapsedNow().inWholeMilliseconds
+                    // レスポンスを受け取った時点でフックが完了していることの確認。
+                    // Lambdaはレスポンス送出でinvocationが終了し実行環境がfreezeされるため、
+                    // レスポンス後に走るフックは送信されないまま凍結する。
+                    verify { hookSlow() }
+                    elapsed shouldBeGreaterThanOrEqual SLOW_HOOK_DELAY
                 }
             }
             it("should run successfully when hook throws") {


### PR DESCRIPTION
## 概要

記事を投稿してもVercelのデプロイがキックされない問題を修正する。**Lambda移行で顕在化した障害。**

## 症状

記事投稿後、TiDBには登録され`201 Created`が返るのに、サイトが再ビルドされない。

```text
09:53:20  201 Created: POST - /api/v1/entries in 1040ms   ← 登録は成功
```

`totalCount` は 180 → 181 に増えているが、`www.miyado.dev/entries/90179` は 302（記事ページが存在しない）。

## 原因

フックは `ApplicationCallPipeline.Call` の**直後**に挿入されたフェーズで実行されていた。この位置は**ハンドラがレスポンスを書き終えた後**にあたる。

- **EC2**: プロセスが動き続けるため、レスポンス後でも送信が完了していた
- **Lambda**: Lambda Web Adapterがレスポンスを受け取った時点でinvocationが終了し、**実行環境がfreezeされる**。フックのHTTPリクエストは飛びきる前に凍結する

`Call` の**前**に移すのは解にならない。ハンドラがまだ動いておらず、記事が作られていないため。

**「記事は作成済み」かつ「レスポンス未送出」を同時に満たすのは送信パイプラインの入口だけ**なので、`ApplicationSendPipeline.Before` に移し、フックの完了を待ってからレスポンスを返すようにした。

## 調査中に見つかった、障害を隠していた2点

### 1. ステータスに関係なく発火していた

調査ログにこの並びが残っていた:

```text
09:53:19  403 Forbidden: POST - /api/v1/entries   ← CSRFトークン無しの1回目
09:53:20  201 Created:  POST - /api/v1/entries   ← 本命
```

**403のときもVercelを叩いていた。** 記事が作られていないのにビルドが走る。失敗レスポンスでは発火しないようにした。

### 2. 失敗が一切観測できなかった

```kotlin
catch (e: Throwable) { logger?.error(e.message) }  // message が null なら空行だけ
client.post(configuration.requestTo) {}            // レスポンスを見ていない
```

例外も4xx/5xxも痕跡が残らない。CloudWatchを追っても手がかりがゼロだったのはこれが理由。例外はスタックトレース付きで記録するようにした。

## ステータス判定を「失敗が判明したときだけ止める」にした理由

当初は「成功が確認できたときだけ送る」と実装したが、**既存テストが軒並み落ちた**。各送信フェーズを実測して原因が分かった:

```text
call.respond("ok") のとき
  Before          -> status=null
  Transform       -> status=null
  Render          -> status=null
  ContentEncoding -> status=null
  After           -> status=null
```

**本文だけを返す経路では、送信パイプラインのどのフェーズでも `status()` はnullのまま**で、200はエンジンが最後に補う。「成功と確認できたときだけ送る」にすると、この経路のフックが**黙って落ちる**——本PRが直そうとしているのと同じ「静かに失敗する」バグを作り込むことになる。

そこで判定を反転し、**ステータスが取得できて、かつそれが失敗のときだけスキップ**する形にした。

## その他の変更

`HookFilter` の `pipelinePhase` / `insertAfter` を削除した。どちらも既定値のままでしか使われておらず、**その既定の配置（`Call` の直後）こそがLambdaで壊れた原因**だったため。実行位置は `RequestHook` 側が送信パイプラインに固定する。

## テスト

今回の本質2点を検証するケースを追加した。

| テスト | 検証内容 |
|---|---|
| `should finish the hook before sending the response` | 遅いフック（300ms）を仕込み、**レスポンスがその分待たされること**を確認。レスポンス到達時点でフックが完了している証明 |
| `should not run hook when the response is not successful` | 403を返す経路でフックが発火しないこと |

既存ケースも、ステータスを明示する経路（`respond(HttpStatusCode.OK)`）と本文だけの経路（`respond("ok")`）の**両方**を通るようにした。

- [x] `./gradlew build ktlintCheck` → **BUILD SUCCESSFUL**（karate e2e 12件を含む）
- [x] `RequestHookTest` / `InstallRequestHookKtTest` 計6件すべてPASSED

## レビュー観点

- 実行位置を `ApplicationSendPipeline.Before` にした判断
- ステータス判定を「失敗のときだけスキップ」にした判断（上記の実測根拠）
- レスポンスがフックの完了を待つことによるレイテンシ増（記事投稿時のみ、Vercelへの往復分）
- `HookFilter` からのフェーズ指定の削除

## デプロイ後に確認したいこと

記事を投稿して、Vercelのダッシュボードに**Deploy Hook由来**のデプロイが現れること。あわせてCloudWatchでフック失敗のログが出ていないこと。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
