### PR TITLE
fix(ci): Claude ワークフローの checkout 追加と GitHub Actions の SHA pinning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ jobs:
       backend: ${{ steps.changes.outputs.backend }}
       frontend: ${{ steps.changes.outputs.frontend }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: changes
         with:
           filters: |
@@ -33,11 +33,11 @@ jobs:
     if: ${{ needs.check_changes.outputs.backend == 'true' }}
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: Lint Code Base
-        uses: github/super-linter/slim@v7
+        uses: github/super-linter/slim@b807e99ddd37e444d189cfd2c2ca1274d8ae8ef1 # v7
         env:
           # api-spec/ is a multi-file OpenAPI bundle (root.json + fragments) that
           # relies on openapi-generator's lenient $ref resolution; the fragments
@@ -62,17 +62,17 @@ jobs:
     if: ${{ needs.check_changes.outputs.backend == 'true' }}
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - uses: jdx/mise-action@v4
+      - uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4.2.3
         with:
           install_args: "java"
       - name: Resolve Java Docker tag from mise.toml
         working-directory: backend
         run: echo "JAVA_DOCKER_TAG=$(sh scripts/mise-java-docker-tag.sh)" >> "$GITHUB_ENV"
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Prepare env
         working-directory: backend
         run: |
@@ -124,7 +124,7 @@ jobs:
       # 失敗したテストの詳細ログを出力
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-results
           path: |
@@ -137,11 +137,11 @@ jobs:
     needs: check_changes
     if: ${{ needs.check_changes.outputs.frontend == 'true' }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v7
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: 'frontend/package.json'
           cache: 'pnpm'

--- a/.github/workflows/claude-fix-renovate.yml
+++ b/.github/workflows/claude-fix-renovate.yml
@@ -73,7 +73,7 @@ jobs:
           gh pr comment "${{ steps.pr.outputs.number }}" --repo "${{ github.repository }}" --body \
             "既に自動修正を1回試みましたが、CI が再度失敗しました。人手での確認をお願いします。"
 
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: steps.guard.outputs.already_attempted == 'false'
         with:
           ref: ${{ github.event.workflow_run.head_branch }}

--- a/.github/workflows/claude-issue-dev.yml
+++ b/.github/workflows/claude-issue-dev.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       # claude-code-action は作業ブランチの作成やコミットをワークスペース上の
       # git リポジトリに対して行うため、checkout が必須。
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude-issue-dev.yml
+++ b/.github/workflows/claude-issue-dev.yml
@@ -16,6 +16,12 @@ jobs:
       issues: write
       id-token: write
     steps:
+      # claude-code-action は作業ブランチの作成やコミットをワークスペース上の
+      # git リポジトリに対して行うため、checkout が必須。
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
       - uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1.0.183
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -31,6 +31,12 @@ jobs:
       issues: write
       id-token: write
     steps:
+      # claude-code-action は作業ブランチの作成やコミットをワークスペース上の
+      # git リポジトリに対して行うため、checkout が必須。
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
       - uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1.0.183
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       # claude-code-action は作業ブランチの作成やコミットをワークスペース上の
       # git リポジトリに対して行うため、checkout が必須。
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
 

--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -15,10 +15,10 @@ jobs:
     outputs:
       backend: ${{ steps.changes.outputs.backend }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: changes
         with:
           filters: |
@@ -47,7 +47,7 @@ jobs:
       contents: read
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: git setting
         run: |
@@ -55,7 +55,7 @@ jobs:
           git config --local user.name "hmiyado"
 
       - name: Set up Java
-        uses: jdx/mise-action@v4
+        uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4.2.3
         with:
           install_args: "java"
 
@@ -74,13 +74,13 @@ jobs:
       # 長期AWSクレデンシャルを持たずOIDCでロールを引き受ける。
       # ロールARNはリポジトリVariable (機密ではないためSecretにしていない)。
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           role-to-assume: ${{ vars.AWS_GITHUB_ACTIONS_ROLE_ARN }}
           aws-region: us-east-2
 
       - name: Log in to Amazon ECR
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2.1.6
         id: ecr-login
 
       # フェーズ9でEC2（amd64）を撤去し、ビルド対象はarm64のみになった。
@@ -88,10 +88,10 @@ jobs:
       # （buildxは非ネイティブアーキテクチャのビルドをbinfmt_misc経由のQEMUエミュレーション
       # に頼るため、単一プラットフォームであってもクロスビルドである限り不要にはならない）。
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       # ECR: arm64 -> Lambda (Graviton) が使う。
       #
@@ -103,7 +103,7 @@ jobs:
       # provenance: false が必須。buildxはattestationを付けるとその紐付け先として
       # インデックスを作るため、platformsを1つに絞ってもインデックスになってしまう。
       - name: Build and push Docker image (arm64, ECR)
-        uses: docker/build-push-action@v7.3.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ./backend
           push: true

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "helpers:pinGitHubActionDigests"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
## 背景

issue #540 で Claude Issue Development ワークフローが失敗した。

```
Creating local branch claude/issue-540-... from source branch: main...
fatal: not a git repository (or any of the parent directories): .git
```

claude-code-action の tag モードは作業ブランチの作成やコミットをワークスペース上の git リポジトリに対して行うが、`actions/checkout` が無いためワークスペースが空で、`git fetch origin main --depth=1` が exit 128 で落ちていた。

## 変更内容

### 1. `actions/checkout` の追加

- `claude-issue-dev.yml` — 今回失敗したワークフロー
- `claude.yml` — 同じ抜けがあり、issue コメントからブランチを作れば同様に落ちる潜在バグだった

アクション側が必要な ref を自前で fetch するため `fetch-depth: 1` で足りる。既存の `claude-fix-renovate.yml` は元ブランチへのコミットが必要なので `fetch-depth: 0` のまま。

### 2. GitHub Actions を コミット SHA で pin

タグは同名のまま別コミットを指すよう付け替えられるため、サードパーティ製アクションの改ざんやアカウント乗っ取りがそのまま CI に流れ込むリスクがある。全ワークフローの `uses:` 26 箇所を完全なコミット SHA で固定し、可読性のため対応バージョンをコメントで残した。

| アクション | SHA | バージョン |
|---|---|---|
| actions/checkout | `3d3c42e5` | v7.0.1 |
| actions/setup-node | `82076278` | v7.0.0 |
| actions/upload-artifact | `043fb46d` | v7.0.1 |
| dorny/paths-filter | `7b450fff` | v4.0.2 |
| jdx/mise-action | `9e7f7633` | v4.2.3 |
| aws-actions/configure-aws-credentials | `e6de0542` | v6.2.3 |
| aws-actions/amazon-ecr-login | `d539f093` | v2.1.6 |
| docker/setup-qemu-action | `96fe6ef7` | v4.2.0 |
| docker/setup-buildx-action | `bb05f3f5` | v4.2.0 |
| docker/build-push-action | `53b7df96` | v7.3.0 |
| github/super-linter/slim | `b807e99d` | v7 |
| pnpm/action-setup | `0ebf4713` | v6.0.9 |

`anthropics/claude-code-action` は元から pin 済み。参照先のバージョンは変えていない（既存タグが指すコミットをそのまま固定しただけ）。

### 3. Renovate による pin の自動化

`helpers:pinGitHubActionDigests` プリセットを追加。今後ワークフローにタグ参照のアクションを足しても Renovate が pin する PR を作成するため、SHA 固定の運用が手作業に依存しない。

## 補足: super-linter が古い

pin 作業中に判明した別件。`github/super-linter` の `v7` タグは 2024-08-29 のコミットで止まっており（v7 系のパッチタグは存在しない）、本家は `super-linter/super-linter` に移って v8.7.0 まで進んでいる。**この PR が原因ではなく `@v7` の時点で既にそうだった**が、移行は別途検討したい。

## 確認したこと

- 全ワークフローの YAML パースが通ること
- ワークフローの差分が `uses:` 行のみであること
- `helpers:pinGitHubActionDigests` が Renovate 本体に実在すること（`matchDepTypes: ['action']` に `pinDigests: true`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)