### PR TITLE
記事削除UIの実装

### DIFF
--- a/backend/src/main/resources/application.conf
+++ b/backend/src/main/resources/application.conf
@@ -73,5 +73,12 @@ ktor {
       requestTo = "http://localhost:8080/on-new-comment-created"
       requestTo = ${?VERCEL_DEPLOY_HOOK}
     }
+    {
+      name = "on entry deleted"
+      method = "delete"
+      path = "/api/v1/entries/{serialNumber}"
+      requestTo = "http://localhost:8080/on-entry-deleted"
+      requestTo = ${?VERCEL_DEPLOY_HOOK}
+    }
   ]
 }

--- a/frontend/src/components/presentation/entries/entries.test.tsx
+++ b/frontend/src/components/presentation/entries/entries.test.tsx
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import Entries from './entries'
+import { EntryProps } from '../../plurals/entry/entry'
+import UserContext from '../../../context/user'
+import EntryRepository from '../../../repository/entry/entryRepository'
+
+vi.mock('../../plurals/comment/commentlist/commentlist', () => ({
+  default: () => <></>,
+}))
+
+vi.mock('../../../repository/entry/entryRepository', () => ({
+  default: {
+    deleteEntry: vi.fn(),
+  },
+}))
+
+const entry: EntryProps = {
+  serialNumber: 1,
+  title: 'title',
+  body: 'body',
+  time: '2021-11-23T23:31:20+09:00',
+  author: 'name',
+  commentsCount: 0,
+}
+
+const deleteButton = () => screen.queryByText('削除する')
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('Entries', () => {
+  test('should not show delete button when not signed in', () => {
+    render(
+      <UserContext.Provider value={{ user: null, updateUser: () => {} }}>
+        <Entries entry={entry} />
+      </UserContext.Provider>,
+    )
+    expect(deleteButton()).toBeNull()
+  })
+
+  test('should show delete button when signed in', () => {
+    render(
+      <UserContext.Provider
+        value={{
+          user: { id: 1, screenName: 'admin', accountLinks: [] },
+          updateUser: () => {},
+        }}
+      >
+        <Entries entry={entry} />
+      </UserContext.Provider>,
+    )
+    expect(deleteButton()).not.toBeNull()
+  })
+
+  test('should delete entry when delete button is clicked and confirmed', () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    render(
+      <UserContext.Provider
+        value={{
+          user: { id: 1, screenName: 'admin', accountLinks: [] },
+          updateUser: () => {},
+        }}
+      >
+        <Entries entry={entry} />
+      </UserContext.Provider>,
+    )
+    fireEvent.click(deleteButton()!)
+    expect(EntryRepository.deleteEntry).toHaveBeenCalledWith(1)
+  })
+
+  test('should not delete entry when delete is not confirmed', () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(false)
+    render(
+      <UserContext.Provider
+        value={{
+          user: { id: 1, screenName: 'admin', accountLinks: [] },
+          updateUser: () => {},
+        }}
+      >
+        <Entries entry={entry} />
+      </UserContext.Provider>,
+    )
+    fireEvent.click(deleteButton()!)
+    expect(EntryRepository.deleteEntry).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/presentation/entries/entries.tsx
+++ b/frontend/src/components/presentation/entries/entries.tsx
@@ -1,13 +1,17 @@
 import EntryComponent, { EntryProps } from '../../plurals/entry/entry'
 import CommentList from '../../plurals/comment/commentlist/commentlist'
-import { Suspense } from 'react'
+import { Suspense, useContext } from 'react'
 import CommentLoading from '../../plurals/comment/commentloading/commentloading'
 import ErrorBoundary from '../../plurals/errorboundary/errorboundary'
+import Button from '../../pieces/button/button'
+import UserContext from '../../../context/user'
+import EntryRepository from '../../../repository/entry/entryRepository'
 
 const styles = {
   entry: [
     'border-b-1 border-light-surface-overlay-border dark:border-dark-surface-overlay-border',
   ].join(' '),
+  deleteButtonContainer: ['mt-0.5'].join(' '),
   commentListContainer: ['ml-2.0 lg:ml-4.5'].join(' '),
 }
 
@@ -16,9 +20,27 @@ export default function Entries({
 }: {
   entry: EntryProps
 }): React.JSX.Element {
+  const { user } = useContext(UserContext)
+
+  const handleDelete = () => {
+    const shouldDelete = window.confirm(
+      'この記事を削除しますか？ この操作は取り消せません。',
+    )
+    if (!shouldDelete) {
+      return
+    }
+    EntryRepository.deleteEntry(entry.serialNumber)
+    window.location.href = '/'
+  }
+
   return (
     <>
       <EntryComponent props={{ ...entry, className: styles.entry }} />
+      {user !== null && (
+        <div className={styles.deleteButtonContainer}>
+          <Button text="削除する" onClick={handleDelete} />
+        </div>
+      )}
       <div className={styles.commentListContainer}>
         <ErrorBoundary>
           <Suspense fallback={<CommentLoading />}>

--- a/frontend/src/repository/entry/entryRepository.test.ts
+++ b/frontend/src/repository/entry/entryRepository.test.ts
@@ -30,4 +30,8 @@ describe('entryRepository', () => {
       },
     })
   })
+
+  test('can delete an entry', async () => {
+    await expect(EntryRepository.deleteEntry(1)).resolves.not.toThrow()
+  })
 })

--- a/frontend/src/repository/entry/entryRepository.ts
+++ b/frontend/src/repository/entry/entryRepository.ts
@@ -20,6 +20,10 @@ const fetchEntry = async (serialNumber: number) => {
   return KottageClient.entriesSerialNumberGet({ serialNumber })
 }
 
+const deleteEntry = async (serialNumber: number) => {
+  return KottageClient.entriesSerialNumberDelete({ serialNumber })
+}
+
 const createComment = async (
   serialNumber: number,
   name: string,
@@ -42,6 +46,7 @@ const EntryRepository = {
   createEntry,
   getEntries,
   fetchEntry,
+  deleteEntry,
   createComment,
   fetchComments,
 }

--- a/frontend/src/test/mocks/requestHandlers.ts
+++ b/frontend/src/test/mocks/requestHandlers.ts
@@ -81,6 +81,11 @@ export const requestHandlers = [
       },
     )
   }),
+  http.delete(url('/api/v1/entries/1'), () => {
+    return new HttpResponse(null, {
+      status: 200,
+    })
+  }),
   http.post(url('/api/v1/sign-in'), () => {
     return HttpResponse.json(
       {


### PR DESCRIPTION
## 概要

管理者としてログインしている場合に、記事詳細ページに削除ボタンを表示し、押下すると確認ダイアログ後に記事を削除するようにしました。

- 既存の `DELETE /api/v1/entries/{serialNumber}` エンドポイント（管理者限定）を利用
- 削除後はホームへリダイレクト
- 記事作成・コメント作成と同様に、削除エンドポイントにも Vercel デプロイフックフックを発火する webhook を application.conf に追加

Closes #540

🤖 Generated with [Claude Code](https://claude.ai/code)