### PR TITLE
chore(mise): mise.toml から pnpm を外す

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,6 @@
+# pnpm はここでは管理しない。バージョンは package.json の packageManager が
+# 単一の情報源で、pnpm 自身が該当バージョンを取得して実行する。
 [tools]
 node = "24"
 java = "temurin-21.0.11+10.0.LTS"
-pnpm = "11.17.0"
 terraform = "1.15.8"


### PR DESCRIPTION
## 背景

`mise.toml` は `pnpm = "11.17.0"` を宣言していたが、**実際には一度も使われていなかった**。

`.zshrc` が `mise activate` の後で `PNPM_HOME` を PATH の先頭に追加するため、常に `~/Library/pnpm/pnpm` が mise のシムより優先される。その結果 mise 側には pnpm がインストールされず、`mise current` が以下を警告し続ける状態だった。

```
mise WARN  pnpm@11.17.0 is specified in ~/projects/kottage/mise.toml, but not installed
```

## 変更内容

バージョンの単一の情報源を `package.json` の `packageManager: pnpm@11.17.0` に統一し、実態に合わない宣言を削除する。pnpm 自身が `packageManager` を読んで該当バージョンを取得・実行するため、開発者の手元の挙動は変わらない。

## CI への影響

無し。根拠は以下のとおり。

- `ci.yml` の `backend_test`、`delivery.yml` の `build` はいずれも `jdx/mise-action` を `install_args: "java"` で使っており、mise から取得するのは java のみ
- `ci.yml` の `frontend_test` は `pnpm/action-setup`（`packageManager` を参照）と `actions/setup-node`（`node-version-file: frontend/package.json` を参照）を使っており、mise を経由しない
- `backend/scripts/mise-java-docker-tag.sh` は `^java[[:space:]]*=` の行しか grep しない

## 手元での確認

| 項目 | 結果 |
|---|---|
| `mise current` | node 24.14.1 / java temurin-21 / terraform 1.15.8（pnpm の missing 警告が解消） |
| `pnpm -v` | 11.17.0（`~/Library/pnpm/pnpm`、変更前と同じ） |
| `pnpm store path` | `~/Library/pnpm/store/v11` |
| pre-commit フック | 正常終了 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)